### PR TITLE
Parse funcRef refName correctly

### DIFF
--- a/model/function.go
+++ b/model/function.go
@@ -58,7 +58,7 @@ func (f *FunctionRef) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	f.RefName = requiresNotNilOrEmpty("refName")
+	f.RefName = requiresNotNilOrEmpty(funcRef["refName"])
 	if _, found := funcRef["arguments"]; found {
 		f.Arguments = funcRef["arguments"].(map[string]interface{})
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -26,12 +26,14 @@ func TestFromFile(t *testing.T) {
 		"./testdata/greetings.sw.json": func(t *testing.T, w *model.Workflow) {
 			assert.Equal(t, "greeting", w.ID)
 			assert.IsType(t, &model.OperationState{}, w.States[0])
+			assert.Equal(t, "greetingFunction", w.States[0].(*model.OperationState).Actions[0].FunctionRef.RefName)
 		},
 		"./testdata/greetings.sw.yaml": func(t *testing.T, w *model.Workflow) {
 			assert.IsType(t, &model.OperationState{}, w.States[0])
 			assert.Equal(t, "greeting", w.ID)
 			assert.NotEmpty(t, w.States[0].(*model.OperationState).Actions)
 			assert.NotNil(t, w.States[0].(*model.OperationState).Actions[0].FunctionRef)
+			assert.Equal(t, "greetingFunction", w.States[0].(*model.OperationState).Actions[0].FunctionRef.RefName)
 		},
 		"./testdata/eventbasedgreeting.sw.json": func(t *testing.T, w *model.Workflow) {
 			assert.Equal(t, "GreetingEvent", w.Events[0].Name)


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
When parsing the workflow, function.go sets the refname to a hardcoded "refName" string. This skips any refName set in the YAML/JSON.

Instead, we should use the available funcRef map to grab the "refName" value.


**Special notes for reviewers**:

**Additional information (if needed):**
Co-PR with @VicNgu
