### PR TITLE
remove subflow State type, add subFlowRef to Action

### DIFF
--- a/model/event.go
+++ b/model/event.go
@@ -15,9 +15,10 @@
 package model
 
 import (
+	"reflect"
+
 	val "github.com/serverlessworkflow/sdk-go/validator"
 	"gopkg.in/go-playground/validator.v8"
-	"reflect"
 )
 
 const (
@@ -77,4 +78,12 @@ type EventRef struct {
 	Data interface{} `json:"data,omitempty"`
 	// Add additional extension context attributes to the produced event
 	ContextAttributes map[string]interface{} `json:"contextAttributes,omitempty"`
+}
+
+// SubFlowRef ...
+type SubFlowRef struct {
+	// Sub-workflow unique id
+	WorkflowID string `json:"workflowId" validate:"required"`
+	// Sub-workflow version
+	Version string `json:"version,omitempty"`
 }

--- a/model/states.go
+++ b/model/states.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"encoding/json"
+
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -32,8 +33,6 @@ const (
 	StateTypeSwitch = "switch"
 	// StateTypeForEach ...
 	StateTypeForEach = "foreach"
-	// StateTypeSubflow ...
-	StateTypeSubflow = "subflow"
 	// StateTypeInject ...
 	StateTypeInject = "inject"
 	// StateTypeCallback ...
@@ -187,17 +186,6 @@ type ParallelState struct {
 	N intstr.IntOrString `json:"n,omitempty"`
 }
 
-// SubflowState Defines a sub-workflow to be executed
-type SubflowState struct {
-	BaseState
-	// Workflow execution must wait for sub-workflow to finish before continuing
-	WaitForCompletion bool `json:"waitForCompletion,omitempty"`
-	// Sub-workflow unique id
-	WorkflowID string `json:"workflowId" validate:"required"`
-	// SubFlow state repeat exec definition
-	Repeat Repeat `json:"repeat,omitempty"`
-}
-
 // InjectState ...
 type InjectState struct {
 	BaseState
@@ -218,8 +206,6 @@ type ForEachState struct {
 	Max intstr.IntOrString `json:"max,omitempty"`
 	// Actions to be executed for each of the elements of inputCollection
 	Actions []Action `json:"actions,omitempty"`
-	// Unique Id of a workflow to be executed for each of the elements of inputCollection
-	WorkflowID string `json:"workflowId,omitempty"`
 }
 
 // CallbackState ...

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -39,7 +39,6 @@ var actionsModelMapping = map[string]func(state map[string]interface{}) State{
 		}
 		return &EventBasedSwitchState{}
 	},
-	StateTypeSubflow:  func(map[string]interface{}) State { return &SubflowState{} },
 	StateTypeInject:   func(map[string]interface{}) State { return &InjectState{} },
 	StateTypeForEach:  func(map[string]interface{}) State { return &ForEachState{} },
 	StateTypeCallback: func(map[string]interface{}) State { return &CallbackState{} },
@@ -330,6 +329,8 @@ type Action struct {
 	FunctionRef FunctionRef `json:"functionRef,omitempty"`
 	// References a 'trigger' and 'result' reusable event definitions
 	EventRef EventRef `json:"eventRef,omitempty"`
+	// References a sub-workflow to be executed
+	SubFlowRef SubFlowRef `json:"subFlowRef,omitempty"`
 	// Time period to wait for function execution to complete
 	Timeout string `json:"timeout,omitempty"`
 	// Action data filter
@@ -401,8 +402,6 @@ type Branch struct {
 	Name string `json:"name" validate:"required"`
 	// Actions to be executed in this branch
 	Actions []Action `json:"actions,omitempty"`
-	// Unique Id of a workflow to be executed in this branch
-	WorkflowID string `json:"workflowId,omitempty"`
 }
 
 // ActionDataFilter ...

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -66,6 +66,11 @@ func TestFromFile(t *testing.T) {
 			assert.IsType(t, &model.TransitionDataCondition{}, eventState.DataConditions[0])
 			assert.Equal(t, "TimeoutRetryStrategy", w.Retries[0].Name)
 			assert.Equal(t, "CheckApplication", w.Start.StateName)
+			assert.IsType(t, &model.OperationState{}, w.States[1])
+			operationState := w.States[1].(*model.OperationState)
+			assert.NotNil(t, operationState)
+			assert.NotEmpty(t, operationState.Actions)
+			assert.Equal(t, "startApplicationWorkflowId", operationState.Actions[0].SubFlowRef.WorkflowID)
 		},
 		"./testdata/applicationrequest.rp.json": func(t *testing.T, w *model.Workflow) {
 			assert.IsType(t, &model.DataBasedSwitchState{}, w.States[0])

--- a/parser/testdata/applicationrequest-issue16.sw.yaml
+++ b/parser/testdata/applicationrequest-issue16.sw.yaml
@@ -31,8 +31,10 @@ states:
     default:
       transition: RejectApplication
   - name: StartApplication
-    type: subflow
-    workflowId: startApplicationWorkflowId
+    type: operation
+    actions:
+      - subFlowRef:
+          workflowId: startApplicationWorkflowId
     end: true
   - name: RejectApplication
     type: operation

--- a/parser/testdata/applicationrequest.json
+++ b/parser/testdata/applicationrequest.json
@@ -43,8 +43,14 @@
     },
     {
       "name": "StartApplication",
-      "type": "subflow",
-      "workflowId": "startApplicationWorkflowId",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": {
+            "workflowId": "startApplicationWorkflowId"
+          }
+        }
+      ],
       "end": {
         "terminate": true
       }

--- a/parser/testdata/applicationrequest.rp.json
+++ b/parser/testdata/applicationrequest.rp.json
@@ -34,8 +34,14 @@
     },
     {
       "name": "StartApplication",
-      "type": "subflow",
-      "workflowId": "startApplicationWorkflowId",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": {
+            "workflowId": "startApplicationWorkflowId"
+          }
+        }
+      ],
       "end": {
         "terminate": true
       }

--- a/parser/testdata/applicationrequest.url.json
+++ b/parser/testdata/applicationrequest.url.json
@@ -34,8 +34,14 @@
     },
     {
       "name": "StartApplication",
-      "type": "subflow",
-      "workflowId": "startApplicationWorkflowId",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": {
+            "workflowId": "startApplicationWorkflowId"
+          }
+        }
+      ],
       "end": {
         "terminate": true
       }

--- a/parser/testdata/eventbasedswitch.sw.json
+++ b/parser/testdata/eventbasedswitch.sw.json
@@ -45,24 +45,42 @@
     },
     {
       "name": "HandleApprovedVisa",
-      "type": "subflow",
-      "workflowId": "handleApprovedVisaWorkflowID",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": {
+            "workflowId": "handleApprovedVisaWorkflowID"
+          }
+        }
+      ],
       "end": {
         "terminate": true
       }
     },
     {
       "name": "HandleRejectedVisa",
-      "type": "subflow",
-      "workflowId": "handleRejectedVisaWorkflowID",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": {
+            "workflowId": "handleRejectedVisaWorkflowID"
+          }
+        }
+      ],
       "end": {
         "terminate": true
       }
     },
     {
       "name": "HandleNoVisaDecision",
-      "type": "subflow",
-      "workflowId": "handleNoVisaDecisionWorkfowId",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": {
+            "workflowId": "handleNoVisaDecisionWorkfowId"
+          }
+        }
+      ],
       "end": {
         "terminate": true
       }

--- a/parser/testdata/provisionorders.sw.json
+++ b/parser/testdata/provisionorders.sw.json
@@ -56,32 +56,56 @@
     },
     {
       "name": "MissingId",
-      "type": "subflow",
-      "workflowId": "handleMissingIdExceptionWorkflow",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": {
+            "workflowId": "handleMissingIdExceptionWorkflow"
+          }
+        }
+      ],
       "end": {
         "terminate": true
       }
     },
     {
       "name": "MissingItem",
-      "type": "subflow",
-      "workflowId": "handleMissingItemExceptionWorkflow",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": {
+            "workflowId": "handleMissingItemExceptionWorkflow"
+          }
+        }
+      ],
       "end": {
         "terminate": true
       }
     },
     {
       "name": "MissingQuantity",
-      "type": "subflow",
-      "workflowId": "handleMissingQuantityExceptionWorkflow",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": {
+            "workflowId": "handleMissingQuantityExceptionWorkflow"
+          }
+        }
+      ],
       "end": {
         "terminate": true
       }
     },
     {
       "name": "ApplyOrder",
-      "type": "subflow",
-      "workflowId": "applyOrderWorkflowId",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": {
+            "workflowId": "applyOrderWorkflowId"
+          }
+        }
+      ],
       "end": {
         "terminate": true
       }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
This PR fixes "subflow" states to match what is in the specification: https://github.com/serverlessworkflow/specification/blob/main/specification.md#subflowref-definition

It removes the non-existent "subflow" State type, and adds the "subFlowRef" field to Action.
This also includes removing "workflowId" from other state types, as is is now done via Actions.

**Special notes for reviewers**:

**Additional information (if needed):**
By default the "subFlowRef" uses the full object type with "workflowId" and "version" fields, instead of the shorthand notation of just using the workflowId string. This is to be consistent with other fields which can have both string and object values.
