### PR TITLE
fix missing unmarshal for FunctionRef.SelectionSet

### DIFF
--- a/model/function.go
+++ b/model/function.go
@@ -66,6 +66,7 @@ func (f *FunctionRef) UnmarshalJSON(data []byte) error {
 	if _, found := funcRef["arguments"]; found {
 		f.Arguments = funcRef["arguments"].(map[string]interface{})
 	}
+	f.SelectionSet = requiresNotNilOrEmpty(funcRef["selectionSet"])
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: mattgarmon <mjg2790@gmail.com>

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
This PR fixes the missing unmarshal for FuntionRef.SelectionSet
The bug was introduced by https://github.com/serverlessworkflow/sdk-go/pull/38

**Special notes for reviewers**:

**Additional information (if needed):**
