### PR TITLE
Changed Retry.Multiplier, OnError.Transition, OnError.End to pointer

### DIFF
--- a/model/retry.go
+++ b/model/retry.go
@@ -30,7 +30,7 @@ type Retry struct {
 	// Static value by which the delay increases during each attempt (ISO 8601 time format)
 	Increment string `json:"increment,omitempty"`
 	// Numeric value, if specified the delay between retries is multiplied by this value.
-	Multiplier floatstr.Float32OrString `json:"multiplier,omitempty" validate:"omitempty,min=0"`
+	Multiplier *floatstr.Float32OrString `json:"multiplier,omitempty" validate:"omitempty,min=1"`
 	// Maximum number of retry attempts.
 	MaxAttempts intstr.IntOrString `json:"maxAttempts" validate:"required"`
 	// If float type, maximum amount of random time added or subtracted from the delay between each retry relative to total delay (between 0 and 1). If string type, absolute maximum amount of random time added or subtracted from the delay between each retry (ISO 8601 duration format)

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -483,9 +483,9 @@ type OnError struct {
 	// ErrorRefs References one or more workflow error definitions. Used if errorRef is not used
 	ErrorRefs []string `json:"errorRefs,omitempty"`
 	// Transition to next state to handle the error. If retryRef is defined, this transition is taken only if retries were unsuccessful.
-	Transition Transition `json:"transition,omitempty"`
+	Transition *Transition `json:"transition,omitempty"`
 	// End workflow execution in case of this error. If retryRef is defined, this ends workflow only if retries were unsuccessful.
-	End End `json:"end,omitempty"`
+	End *End `json:"end,omitempty"`
 }
 
 // OnEvents ...


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Changed Retry.Multiplier to pointer and changed min=1 (instead of min=0)

in the struct Retry.Multiplier which is a floatstr.Float32OrString, there's no way to distinguish this field as not defined. In the spec, this is supposed to be an optional field. The default struct of Float32OrString will be Type Float and the zero value of FloatVal will be a 0.0 - which will be value if the workflow json/yaml left this out.

Also, minimum of 0 does not make sense

Changed OnError.Transition & OnError.End to pointers for the same reason
**Special notes for reviewers**:

**Additional information (if needed):**
