### PR TITLE
Fix EventState Exclusive parsing interface{} to *bool error

### DIFF
--- a/model/states.go
+++ b/model/states.go
@@ -138,7 +138,7 @@ type DelayState struct {
 type EventState struct {
 	BaseState
 	// If true consuming one of the defined events causes its associated actions to be performed. If false all of the defined events must be consumed in order for actions to be performed
-	Exclusive *bool `json:"exclusive,omitempty"`
+	Exclusive bool `json:"exclusive,omitempty"`
 	// Define the events to be consumed and optional actions to be performed
 	OnEvents []OnEvents `json:"onEvents" validate:"required,min=1,dive"`
 	// State specific timeouts
@@ -156,10 +156,13 @@ func (e *EventState) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if eventStateMap["exclusive"] == nil {
-		e.Exclusive = &TRUE
-	} else {
-		e.Exclusive = eventStateMap["exclusive"].(*bool)
+	e.Exclusive = true
+
+	if eventStateMap["exclusive"] != nil {
+		exclusiveVal, ok := eventStateMap["exclusive"].(bool)
+		if ok {
+			e.Exclusive = exclusiveVal
+		}
 	}
 
 	eventStateRaw := make(map[string]json.RawMessage)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -59,6 +59,29 @@ func TestFromFile(t *testing.T) {
 			assert.NotNil(t, eventState)
 			assert.NotEmpty(t, eventState.OnEvents)
 			assert.Equal(t, "GreetingEvent", eventState.OnEvents[0].EventRefs[0])
+			assert.Equal(t, true, eventState.Exclusive)
+		},
+		"./testdata/workflows/eventbasedgreetingexclusive.sw.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "GreetingEvent", w.Events[0].Name)
+			assert.Equal(t, "GreetingEvent2", w.Events[1].Name)
+			assert.IsType(t, &model.EventState{}, w.States[0])
+			eventState := w.States[0].(*model.EventState)
+			assert.NotNil(t, eventState)
+			assert.NotEmpty(t, eventState.OnEvents)
+			assert.Equal(t, "GreetingEvent", eventState.OnEvents[0].EventRefs[0])
+			assert.Equal(t, "GreetingEvent2", eventState.OnEvents[1].EventRefs[0])
+			assert.Equal(t, true, eventState.Exclusive)
+		},
+		"./testdata/workflows/eventbasedgreetingnonexclusive.sw.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "GreetingEvent", w.Events[0].Name)
+			assert.Equal(t, "GreetingEvent2", w.Events[1].Name)
+			assert.IsType(t, &model.EventState{}, w.States[0])
+			eventState := w.States[0].(*model.EventState)
+			assert.NotNil(t, eventState)
+			assert.NotEmpty(t, eventState.OnEvents)
+			assert.Equal(t, "GreetingEvent", eventState.OnEvents[0].EventRefs[0])
+			assert.Equal(t, "GreetingEvent2", eventState.OnEvents[0].EventRefs[1])
+			assert.Equal(t, false, eventState.Exclusive)
 		},
 		"./testdata/workflows/eventbasedgreeting.sw.p.json": func(t *testing.T, w *model.Workflow) {
 			assert.Equal(t, "GreetingEvent", w.Events[0].Name)

--- a/parser/testdata/workflows/eventbasedgreetingexclusive.sw.json
+++ b/parser/testdata/workflows/eventbasedgreetingexclusive.sw.json
@@ -1,0 +1,79 @@
+{
+  "id": "eventbasedgreetingexclusive",
+  "version": "1.0",
+  "name": "Event Based Greeting Workflow",
+  "description": "Event Based Greeting",
+  "specVersion": "0.7",
+  "start": {
+    "stateName": "Greet"
+  },
+  "events": [
+    {
+      "name": "GreetingEvent",
+      "type": "greetingEventType",
+      "source": "greetingEventSource"
+    },
+    {
+      "name": "GreetingEvent2",
+      "type": "greetingEventType2",
+      "source": "greetingEventSource2"
+    }    
+  ],
+  "functions": [
+    {
+      "name": "greetingFunction",
+      "operation": "file://myapis/greetingapis.json#greeting"
+    }
+  ],
+  "states": [
+    {
+      "name": "Greet",
+      "type": "event",
+      "exclusive": true,
+      "onEvents": [
+        {
+          "eventRefs": [
+            "GreetingEvent"
+          ],
+          "eventDataFilter": {
+            "data": "{{ $.data.greet }}"
+          },
+          "actions": [
+            {
+              "functionRef": {
+                "refName": "greetingFunction",
+                "arguments": {
+                  "name": "{{ $.greet.name }}"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "eventRefs": [
+            "GreetingEvent2"
+          ],
+          "eventDataFilter": {
+            "data": "{{ $.data.greet2 }}"
+          },
+          "actions": [
+            {
+              "functionRef": {
+                "refName": "greetingFunction2",
+                "arguments": {
+                  "name": "{{ $.greet.name }}"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "stateDataFilter": {
+        "output": "{{ $.payload.greeting }}"
+      },
+      "end": {
+        "terminate": true
+      }
+    }
+  ]
+}

--- a/parser/testdata/workflows/eventbasedgreetingnonexclusive.sw.json
+++ b/parser/testdata/workflows/eventbasedgreetingnonexclusive.sw.json
@@ -1,0 +1,62 @@
+{
+  "id": "eventbasedgreetingnonexclusive",
+  "version": "1.0",
+  "name": "Event Based Greeting Workflow",
+  "description": "Event Based Greeting",
+  "specVersion": "0.7",
+  "start": {
+    "stateName": "Greet"
+  },
+  "events": [
+    {
+      "name": "GreetingEvent",
+      "type": "greetingEventType",
+      "source": "greetingEventSource"
+    },
+    {
+      "name": "GreetingEvent2",
+      "type": "greetingEventType2",
+      "source": "greetingEventSource2"
+    }    
+  ],
+  "functions": [
+    {
+      "name": "greetingFunction",
+      "operation": "file://myapis/greetingapis.json#greeting"
+    }
+  ],
+  "states": [
+    {
+      "name": "Greet",
+      "type": "event",
+      "exclusive": false,
+      "onEvents": [
+        {
+          "eventRefs": [
+            "GreetingEvent",
+            "GreetingEvent2"
+          ],
+          "eventDataFilter": {
+            "data": "{{ $.data.greet }}"
+          },
+          "actions": [
+            {
+              "functionRef": {
+                "refName": "greetingFunction",
+                "arguments": {
+                  "name": "{{ $.greet.name }}"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "stateDataFilter": {
+        "output": "{{ $.payload.greeting }}"
+      },
+      "end": {
+        "terminate": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, when the exclusive flag is provided, the code will panic due to interface{} unable to be parsed into a (*bool). This change defaults the exclusive flag to true and sets the value if it is provided as a bool.
