### PR TITLE
Fixed Auth not setting properties field

### DIFF
--- a/model/auth.go
+++ b/model/auth.go
@@ -93,6 +93,8 @@ func (a *Auth) UnmarshalJSON(data []byte) error {
 	if err := unmarshalKey("properties", auth, authProperties); err != nil {
 		return err
 	}
+
+	a.Properties = authProperties
 	return nil
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -112,6 +112,11 @@ func TestFromFile(t *testing.T) {
 			assert.NotNil(t, operationState)
 			assert.NotEmpty(t, operationState.Actions)
 			assert.Equal(t, "startApplicationWorkflowId", operationState.Actions[0].SubFlowRef.WorkflowID)
+			assert.NotNil(t, w.Auth)
+			assert.Equal(t, "testAuth", w.Auth.Name)
+			assert.Equal(t, model.AuthTypeBearer, w.Auth.Scheme)
+			bearerProperties := w.Auth.Properties.(*model.BearerAuthProperties).Token
+			assert.Equal(t, "test_token", bearerProperties)
 		},
 		"./testdata/workflows/applicationrequest.rp.json": func(t *testing.T, w *model.Workflow) {
 			assert.IsType(t, &model.DataBasedSwitchState{}, w.States[0])

--- a/parser/testdata/workflows/applicationrequest.json
+++ b/parser/testdata/workflows/applicationrequest.json
@@ -5,6 +5,13 @@
   "description": "Determine if applicant request is valid",
   "start": "CheckApplication",
   "specVersion": "0.7",
+  "auth": {
+    "name": "testAuth",
+    "scheme": "bearer",
+    "properties": {
+      "token": "test_token"
+    }
+  },
   "functions": [
     {
       "name": "sendRejectionEmailFunction",


### PR DESCRIPTION
Signed-off-by: Victor Nguyen <victor.nguyen@acronis.com>

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**: Auth parsing fails due to Auth.Properties never being set. Properties is already getting unmarshalled, so I just set the Auth.Properties value to the unmarshalled response.

**Special notes for reviewers**:

**Additional information (if needed):**
