### PR TITLE
Support multiple Auths

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -89,7 +89,7 @@ type BaseWorkflow struct {
 	// Auth definitions can be used to define authentication information that should be applied to resources defined in the operation
 	// property of function definitions. It is not used as authentication information for the function invocation,
 	// but just to access the resource containing the function invocation information.
-	Auth *Auth `json:"auth,omitempty"`
+	Auth AuthDefinitions `json:"auth,omitempty"`
 }
 
 // Workflow base definition

--- a/parser/testdata/workflows/applicationrequest.multiauth.json
+++ b/parser/testdata/workflows/applicationrequest.multiauth.json
@@ -1,0 +1,96 @@
+{
+  "id": "applicantrequest",
+  "version": "1.0",
+  "name": "Applicant Request Decision Workflow",
+  "description": "Determine if applicant request is valid",
+  "start": "CheckApplication",
+  "specVersion": "0.7",
+  "auth": [
+    {
+      "name": "testAuth",
+      "scheme": "bearer",
+      "properties": {
+        "token": "test_token"
+      }
+    },
+    {
+      "name": "testAuth2",
+      "scheme": "basic",
+      "properties": {
+        "username": "test_user",
+        "password": "test_pwd"
+      }
+    }
+  ]
+  ,
+  "functions": [
+    {
+      "name": "sendRejectionEmailFunction",
+      "operation": "http://myapis.org/applicationapi.json#emailRejection"
+    }
+  ],
+  "retries": [
+    {
+      "name": "TimeoutRetryStrategy",
+      "delay": "PT1M",
+      "maxAttempts": "5"
+    }
+  ],
+  "states": [
+    {
+      "name": "CheckApplication",
+      "type": "switch",
+      "dataConditions": [
+        {
+          "condition": "{{ $.applicants[?(@.age >= 18)] }}",
+          "transition": {
+            "nextState": "StartApplication"
+          }
+        },
+        {
+          "condition": "{{ $.applicants[?(@.age < 18)] }}",
+          "transition": {
+            "nextState": "RejectApplication"
+          }
+        }
+      ],
+      "default": {
+        "transition": {
+          "nextState": "RejectApplication"
+        }
+      }
+    },
+    {
+      "name": "StartApplication",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": {
+            "workflowId": "startApplicationWorkflowId"
+          }
+        }
+      ],
+      "end": {
+        "terminate": true
+      }
+    },
+    {
+      "name": "RejectApplication",
+      "type": "operation",
+      "actionMode": "sequential",
+      "actions": [
+        {
+          "functionRef": {
+            "refName": "sendRejectionEmailFunction",
+            "parameters": {
+              "applicant": "{{ $.applicant }}"
+            }
+          }
+        }
+      ],
+      "end": {
+        "terminate": true
+      }
+    }
+  ]
+}

--- a/parser/testdata/workflows/witherrors/applicationrequest.authdupl.json
+++ b/parser/testdata/workflows/witherrors/applicationrequest.authdupl.json
@@ -1,0 +1,96 @@
+{
+  "id": "applicantrequest",
+  "version": "1.0",
+  "name": "Applicant Request Decision Workflow",
+  "description": "Determine if applicant request is valid",
+  "start": "CheckApplication",
+  "specVersion": "0.7",
+  "auth": [
+    {
+      "name": "testAuth",
+      "scheme": "bearer",
+      "properties": {
+        "token": "test_token"
+      }
+    },
+    {
+      "name": "testAuth",
+      "scheme": "basic",
+      "properties": {
+        "username": "test_user",
+        "password": "test_pwd"
+      }
+    }
+  ]
+  ,
+  "functions": [
+    {
+      "name": "sendRejectionEmailFunction",
+      "operation": "http://myapis.org/applicationapi.json#emailRejection"
+    }
+  ],
+  "retries": [
+    {
+      "name": "TimeoutRetryStrategy",
+      "delay": "PT1M",
+      "maxAttempts": "5"
+    }
+  ],
+  "states": [
+    {
+      "name": "CheckApplication",
+      "type": "switch",
+      "dataConditions": [
+        {
+          "condition": "{{ $.applicants[?(@.age >= 18)] }}",
+          "transition": {
+            "nextState": "StartApplication"
+          }
+        },
+        {
+          "condition": "{{ $.applicants[?(@.age < 18)] }}",
+          "transition": {
+            "nextState": "RejectApplication"
+          }
+        }
+      ],
+      "default": {
+        "transition": {
+          "nextState": "RejectApplication"
+        }
+      }
+    },
+    {
+      "name": "StartApplication",
+      "type": "operation",
+      "actions": [
+        {
+          "subFlowRef": {
+            "workflowId": "startApplicationWorkflowId"
+          }
+        }
+      ],
+      "end": {
+        "terminate": true
+      }
+    },
+    {
+      "name": "RejectApplication",
+      "type": "operation",
+      "actionMode": "sequential",
+      "actions": [
+        {
+          "functionRef": {
+            "refName": "sendRejectionEmailFunction",
+            "parameters": {
+              "applicant": "{{ $.applicant }}"
+            }
+          }
+        }
+      ],
+      "end": {
+        "terminate": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Signed-off-by: Davide Salerno <dsalerno@redhat.com>

**What this PR does / why we need it**:

This change will let you define multiple authentication methods as described in the specifications and highlighted in this [issue](https://github.com/serverlessworkflow/sdk-go/issues/55)

**Special notes for reviewers**:
In order to avoid to have different authentication methods with the same name, a new custom validator is added into the auth package

**Additional information (if needed):**
Se the specifications https://github.com/serverlessworkflow/specification/blob/main/specification.md#auth-definition