### PR TITLE
test(*): fix unittest assert.NoError checks and msg

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -30,10 +30,11 @@ func TestBasicValidation(t *testing.T) {
 	for _, file := range files {
 		if !file.IsDir() {
 			workflow, err := FromFile(filepath.Join(rootPath, file.Name()))
-			assert.NoError(t, err)
-			assert.NotEmpty(t, workflow.Name)
-			assert.NotEmpty(t, workflow.ID)
-			assert.NotEmpty(t, workflow.States)
+			if assert.NoError(t, err) {
+				assert.NotEmpty(t, workflow.Name)
+				assert.NotEmpty(t, workflow.ID)
+				assert.NotEmpty(t, workflow.States)
+			}
 		}
 	}
 }
@@ -251,8 +252,9 @@ func TestFromFile(t *testing.T) {
 	}
 	for file, f := range files {
 		workflow, err := FromFile(file)
-		assert.NoError(t, err, "Test File", file)
-		assert.NotNil(t, workflow, "Test File", file)
-		f(t, workflow)
+		if assert.NoError(t, err, "Test File %s", file) {
+			assert.NotNil(t, workflow, "Test File %s", file)
+			f(t, workflow)
+		}
 	}
 }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fix the error message in unittest
- always check assert.NoError returns, to avoid when error happened, subsequent sentences panic

**Special notes for reviewers**:

**Additional information (if needed):**
