### PR TITLE
fix(44): add validate for ISO8601 time duration field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/go-playground/validator/v10 v10.11.0
+	github.com/senseyeio/duration v0.0.0-20180430131211-7c2a214ada46
 	github.com/stretchr/testify v1.7.0
 	k8s.io/apimachinery v0.25.0
 	sigs.k8s.io/yaml v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/senseyeio/duration v0.0.0-20180430131211-7c2a214ada46 h1:Dz0HrI1AtNSGCE8LXLLqoZU4iuOJXPWndenCsZfstA8=
+github.com/senseyeio/duration v0.0.0-20180430131211-7c2a214ada46/go.mod h1:is8FVkzSi7PYLWEXT5MgWhglFsyyiW8ffxAoJqfuFZo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/model/delay_state.go
+++ b/model/delay_state.go
@@ -1,0 +1,47 @@
+// Copyright 2022 The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"reflect"
+
+	"github.com/go-playground/validator/v10"
+
+	val "github.com/serverlessworkflow/sdk-go/v2/validator"
+)
+
+func init() {
+	val.GetValidator().RegisterStructValidation(
+		DelayStateStructLevelValidation,
+		DelayState{},
+	)
+}
+
+// DelayState Causes the workflow execution to delay for a specified duration
+type DelayState struct {
+	BaseState
+	// Amount of time (ISO 8601 format) to delay
+	TimeDelay string `json:"timeDelay" validate:"required"`
+}
+
+// DelayStateStructLevelValidation custom validator for DelayState Struct
+func DelayStateStructLevelValidation(structLevel validator.StructLevel) {
+	delayStateObj := structLevel.Current().Interface().(DelayState)
+
+	err := validateISO8601TimeDuration(delayStateObj.TimeDelay)
+	if err != nil {
+		structLevel.ReportError(reflect.ValueOf(delayStateObj.TimeDelay), "TimeDelay", "timeDelay", "reqiso8601duration", "")
+	}
+}

--- a/model/delay_state_test.go
+++ b/model/delay_state_test.go
@@ -1,0 +1,79 @@
+// Copyright 2022 The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	val "github.com/serverlessworkflow/sdk-go/v2/validator"
+)
+
+func TestDelayStateStructLevelValidation(t *testing.T) {
+	type testCase struct {
+		desp          string
+		delayStateObj DelayState
+		err           string
+	}
+	testCases := []testCase{
+		{
+			desp: "normal",
+			delayStateObj: DelayState{
+				BaseState: BaseState{
+					Name: "1",
+					Type: "delay",
+				},
+				TimeDelay: "PT5S",
+			},
+			err: ``,
+		},
+		{
+			desp: "missing required timeDelay",
+			delayStateObj: DelayState{
+				BaseState: BaseState{
+					Name: "1",
+					Type: "delay",
+				},
+				TimeDelay: "",
+			},
+			err: `Key: 'DelayState.TimeDelay' Error:Field validation for 'TimeDelay' failed on the 'required' tag\nKey: 'DelayState.TimeDelay' Error:Field validation for 'TimeDelay' failed on the 'reqiso8601duration' tag`,
+		},
+		{
+			desp: "invalid timeDelay duration",
+			delayStateObj: DelayState{
+				BaseState: BaseState{
+					Name: "1",
+					Type: "delay",
+				},
+				TimeDelay: "P5S",
+			},
+			err: `Key: 'DelayState.TimeDelay' Error:Field validation for 'TimeDelay' failed on the 'reqiso8601duration' tag`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desp, func(t *testing.T) {
+			err := val.GetValidator().Struct(tc.delayStateObj)
+
+			if tc.err != "" {
+				assert.Error(t, err)
+				assert.Regexp(t, tc.err, err)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/model/retry_test.go
+++ b/model/retry_test.go
@@ -1,0 +1,114 @@
+// Copyright 2022 The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/serverlessworkflow/sdk-go/v2/util/floatstr"
+	val "github.com/serverlessworkflow/sdk-go/v2/validator"
+)
+
+func TestRetryStructLevelValidation(t *testing.T) {
+	type testCase struct {
+		desp     string
+		retryObj Retry
+		err      string
+	}
+	testCases := []testCase{
+		{
+			desp: "normal",
+			retryObj: Retry{
+				Name:      "1",
+				Delay:     "PT5S",
+				MaxDelay:  "PT5S",
+				Increment: "PT5S",
+				Jitter:    floatstr.FromString("PT5S"),
+			},
+			err: ``,
+		},
+		{
+			desp: "missing required name",
+			retryObj: Retry{
+				Name:      "",
+				Delay:     "PT5S",
+				MaxDelay:  "PT5S",
+				Increment: "PT5S",
+				Jitter:    floatstr.FromString("PT5S"),
+			},
+			err: `Key: 'Retry.Name' Error:Field validation for 'Name' failed on the 'required' tag`,
+		},
+		{
+			desp: "invalid delay duration",
+			retryObj: Retry{
+				Name:      "1",
+				Delay:     "P5S",
+				MaxDelay:  "PT5S",
+				Increment: "PT5S",
+				Jitter:    floatstr.FromString("PT5S"),
+			},
+			err: `Key: 'Retry.Delay' Error:Field validation for 'Delay' failed on the 'reqiso8601duration' tag`,
+		},
+		{
+			desp: "invdalid max delay duration",
+			retryObj: Retry{
+				Name:      "1",
+				Delay:     "PT5S",
+				MaxDelay:  "P5S",
+				Increment: "PT5S",
+				Jitter:    floatstr.FromString("PT5S"),
+			},
+			err: `Key: 'Retry.MaxDelay' Error:Field validation for 'MaxDelay' failed on the 'reqiso8601duration' tag`,
+		},
+		{
+			desp: "invalid increment duration",
+			retryObj: Retry{
+				Name:      "1",
+				Delay:     "PT5S",
+				MaxDelay:  "PT5S",
+				Increment: "P5S",
+				Jitter:    floatstr.FromString("PT5S"),
+			},
+			err: `Key: 'Retry.Increment' Error:Field validation for 'Increment' failed on the 'reqiso8601duration' tag`,
+		},
+		{
+			desp: "invalid jitter duration",
+			retryObj: Retry{
+				Name:      "1",
+				Delay:     "PT5S",
+				MaxDelay:  "PT5S",
+				Increment: "PT5S",
+				Jitter:    floatstr.FromString("P5S"),
+			},
+			err: `Key: 'Retry.Jitter' Error:Field validation for 'Jitter' failed on the 'reqiso8601duration' tag`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desp, func(t *testing.T) {
+			err := val.GetValidator().Struct(tc.retryObj)
+
+			if tc.err != "" {
+				assert.Error(t, err)
+				assert.Regexp(t, tc.err, err)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/model/states.go
+++ b/model/states.go
@@ -127,13 +127,6 @@ func (s *BaseState) GetStateDataFilter() *StateDataFilter { return s.StateDataFi
 // GetMetadata ...
 func (s *BaseState) GetMetadata() *Metadata { return s.Metadata }
 
-// DelayState Causes the workflow execution to delay for a specified duration
-type DelayState struct {
-	BaseState
-	// Amount of time (ISO 8601 format) to delay
-	TimeDelay string `json:"timeDelay" validate:"required"`
-}
-
 // EventState This state is used to wait for events from event sources, then consumes them and invoke one or more actions to run in sequence or parallel
 type EventState struct {
 	BaseState

--- a/model/util.go
+++ b/model/util.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/senseyeio/duration"
 )
 
 const prefix = "file:/"
@@ -89,4 +91,9 @@ func unmarshalFile(data []byte) (b []byte, err error) {
 		return nil, err
 	}
 	return file, nil
+}
+
+func validateISO8601TimeDuration(s string) error {
+	_, err := duration.ParseISO8601(s)
+	return err
 }

--- a/model/util_test.go
+++ b/model/util_test.go
@@ -1,0 +1,59 @@
+// Copyright 2022 The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateISO8601TimeDuration(t *testing.T) {
+	type testCase struct {
+		desp string
+		s    string
+		err  string
+	}
+	testCases := []testCase{
+		{
+			desp: "normal_all_designator",
+			s:    "P3Y6M4DT12H30M5S",
+			err:  ``,
+		},
+		{
+			desp: "normal_second_designator",
+			s:    "PT5S",
+			err:  ``,
+		},
+		{
+			desp: "empty value",
+			s:    "",
+			err:  `could not parse duration string`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desp, func(t *testing.T) {
+			err := validateISO8601TimeDuration(tc.s)
+
+			if tc.err != "" {
+				assert.Error(t, err)
+				assert.Regexp(t, tc.err, err)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -98,7 +98,7 @@ type Workflow struct {
 	States    []State    `json:"states" validate:"required,min=1"`
 	Events    []Event    `json:"events,omitempty"`
 	Functions []Function `json:"functions,omitempty"`
-	Retries   []Retry    `json:"retries,omitempty"`
+	Retries   []Retry    `json:"retries,omitempty" validate:"dive"`
 }
 
 // UnmarshalJSON implementation for json Unmarshal function for the Workflow type

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -46,7 +46,7 @@ func TestCustomValidators(t *testing.T) {
 	for _, file := range files {
 		if !file.IsDir() {
 			_, err := FromFile(filepath.Join(rootPath, file.Name()))
-			assert.Error(t, err)
+			assert.Error(t, err, "Test File %s", file.Name())
 		}
 	}
 }

--- a/parser/testdata/workflows/witherrors/applicationrequest-issue44.json
+++ b/parser/testdata/workflows/witherrors/applicationrequest-issue44.json
@@ -1,0 +1,85 @@
+{
+    "id": "applicantrequest",
+    "version": "1.0",
+    "name": "Applicant Request Decision Workflow",
+    "description": "Determine if applicant request is valid",
+    "start": "CheckApplication",
+    "specVersion": "0.7",
+    "auth": [{
+      "name": "testAuth",
+      "scheme": "bearer",
+      "properties": {
+        "token": "test_token"
+      }
+    }],
+    "functions": [
+      {
+        "name": "sendRejectionEmailFunction",
+        "operation": "http://myapis.org/applicationapi.json#emailRejection"
+      }
+    ],
+    "retries": [
+      {
+        "name": "TimeoutRetryStrategy",
+        "delay": "P1S",
+        "maxAttempts": "5"
+      }
+    ],
+    "states": [
+      {
+        "name": "CheckApplication",
+        "type": "switch",
+        "dataConditions": [
+          {
+            "condition": "{{ $.applicants[?(@.age >= 18)] }}",
+            "transition": {
+              "nextState": "StartApplication"
+            }
+          },
+          {
+            "condition": "{{ $.applicants[?(@.age < 18)] }}",
+            "transition": {
+              "nextState": "RejectApplication"
+            }
+          }
+        ],
+        "default": {
+          "transition": {
+            "nextState": "RejectApplication"
+          }
+        }
+      },
+      {
+        "name": "StartApplication",
+        "type": "operation",
+        "actions": [
+          {
+            "subFlowRef": {
+              "workflowId": "startApplicationWorkflowId"
+            }
+          }
+        ],
+        "end": {
+          "terminate": true
+        }
+      },
+      {
+        "name": "RejectApplication",
+        "type": "operation",
+        "actionMode": "sequential",
+        "actions": [
+          {
+            "functionRef": {
+              "refName": "sendRejectionEmailFunction",
+              "parameters": {
+                "applicant": "{{ $.applicant }}"
+              }
+            }
+          }
+        ],
+        "end": {
+          "terminate": true
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Signed-off-by: lsytj0413 <511121939@qq.com>

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Add validation for ISO8601 time duration field

**Special notes for reviewers**:

**Additional information (if needed):**

Fixed https://github.com/serverlessworkflow/sdk-go/issues/44
