### PR TITLE
v08 spec alignment - Workflow name no longer a required property

### DIFF
--- a/model/workflow.go
+++ b/model/workflow.go
@@ -58,7 +58,7 @@ type BaseWorkflow struct {
 	// Key Domain-specific workflow identifier
 	Key string `json:"key,omitempty" validate:"omitempty,min=1"`
 	// Workflow name
-	Name string `json:"name" validate:"omitempty"`
+	Name string `json:"name,omitempty"`
 	// Workflow description
 	Description string `json:"description,omitempty"`
 	// Workflow version

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -58,7 +58,7 @@ type BaseWorkflow struct {
 	// Key Domain-specific workflow identifier
 	Key string `json:"key,omitempty" validate:"omitempty,min=1"`
 	// Workflow name
-	Name string `json:"name" validate:"required"`
+	Name string `json:"name" validate:"omitempty"`
 	// Workflow description
 	Description string `json:"description,omitempty"`
 	// Workflow version

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -31,7 +31,6 @@ func TestBasicValidation(t *testing.T) {
 		if !file.IsDir() {
 			workflow, err := FromFile(filepath.Join(rootPath, file.Name()))
 			if assert.NoError(t, err, "Test File %s", file.Name()) {
-				assert.NotEmpty(t, workflow.Name, "Test File %s", file.Name())
 				assert.NotEmpty(t, workflow.ID, "Test File %s", file.Name())
 				assert.NotEmpty(t, workflow.States, "Test File %s", file.Name())
 			}
@@ -54,18 +53,21 @@ func TestCustomValidators(t *testing.T) {
 func TestFromFile(t *testing.T) {
 	files := map[string]func(*testing.T, *model.Workflow){
 		"./testdata/workflows/greetings.sw.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Greeting Workflow", w.Name)
 			assert.Equal(t, "greeting", w.ID)
 			assert.IsType(t, &model.OperationState{}, w.States[0])
 			assert.Equal(t, "greetingFunction", w.States[0].(*model.OperationState).Actions[0].FunctionRef.RefName)
 		},
 		"./testdata/workflows/greetings.sw.yaml": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Greeting Workflow", w.Name)
 			assert.IsType(t, &model.OperationState{}, w.States[0])
 			assert.Equal(t, "greeting", w.ID)
 			assert.NotEmpty(t, w.States[0].(*model.OperationState).Actions)
 			assert.NotNil(t, w.States[0].(*model.OperationState).Actions[0].FunctionRef)
 			assert.Equal(t, "greetingFunction", w.States[0].(*model.OperationState).Actions[0].FunctionRef.RefName)
 		},
-		"./testdata/workflows/greetings-custom-function.sw.yaml": func(t *testing.T, w *model.Workflow) {
+		"./testdata/workflows/greetings-v08-spec.sw.yaml": func(t *testing.T, w *model.Workflow) {
+			assert.Empty(t, w.Name)
 			assert.IsType(t, &model.OperationState{}, w.States[0])
 			assert.Equal(t, "custom.greeting", w.ID)
 			assert.NotEmpty(t, w.States[0].(*model.OperationState).Actions)
@@ -77,12 +79,14 @@ func TestFromFile(t *testing.T) {
 			assert.Equal(t, "greetingCustomFunction", w.States[0].(*model.OperationState).Actions[0].Name)
 		},
 		"./testdata/workflows/eventbaseddataandswitch.sw.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Event Based Switch Transitions", w.Name)
 			assert.Equal(t, "Start", w.States[0].GetName())
 			assert.Equal(t, "CheckVisaStatus", w.States[1].GetName())
 			assert.IsType(t, &model.DataBasedSwitchState{}, w.States[0])
 			assert.IsType(t, &model.EventBasedSwitchState{}, w.States[1])
 		},
 		"./testdata/workflows/eventbasedgreeting.sw.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Event Based Greeting Workflow", w.Name)
 			assert.Equal(t, "GreetingEvent", w.Events[0].Name)
 			assert.IsType(t, &model.EventState{}, w.States[0])
 			eventState := w.States[0].(*model.EventState)
@@ -92,6 +96,7 @@ func TestFromFile(t *testing.T) {
 			assert.Equal(t, true, eventState.Exclusive)
 		},
 		"./testdata/workflows/eventbasedgreetingexclusive.sw.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Event Based Greeting Workflow", w.Name)
 			assert.Equal(t, "GreetingEvent", w.Events[0].Name)
 			assert.Equal(t, "GreetingEvent2", w.Events[1].Name)
 			assert.IsType(t, &model.EventState{}, w.States[0])
@@ -103,6 +108,7 @@ func TestFromFile(t *testing.T) {
 			assert.Equal(t, true, eventState.Exclusive)
 		},
 		"./testdata/workflows/eventbasedgreetingnonexclusive.sw.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Event Based Greeting Workflow", w.Name)
 			assert.Equal(t, "GreetingEvent", w.Events[0].Name)
 			assert.Equal(t, "GreetingEvent2", w.Events[1].Name)
 			assert.IsType(t, &model.EventState{}, w.States[0])
@@ -114,6 +120,7 @@ func TestFromFile(t *testing.T) {
 			assert.Equal(t, false, eventState.Exclusive)
 		},
 		"./testdata/workflows/eventbasedgreeting.sw.p.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Event Based Greeting Workflow", w.Name)
 			assert.Equal(t, "GreetingEvent", w.Events[0].Name)
 			assert.IsType(t, &model.EventState{}, w.States[0])
 			eventState := w.States[0].(*model.EventState)
@@ -122,6 +129,7 @@ func TestFromFile(t *testing.T) {
 			assert.Equal(t, "GreetingEvent", eventState.OnEvents[0].EventRefs[0])
 		},
 		"./testdata/workflows/eventbasedswitch.sw.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Event Based Switch Transitions", w.Name)
 			assert.IsType(t, &model.EventBasedSwitchState{}, w.States[0])
 			eventState := w.States[0].(*model.EventBasedSwitchState)
 			assert.NotNil(t, eventState)
@@ -130,6 +138,7 @@ func TestFromFile(t *testing.T) {
 			assert.IsType(t, &model.TransitionEventCondition{}, eventState.EventConditions[0])
 		},
 		"./testdata/workflows/applicationrequest.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Applicant Request Decision Workflow", w.Name)
 			assert.IsType(t, &model.DataBasedSwitchState{}, w.States[0])
 			eventState := w.States[0].(*model.DataBasedSwitchState)
 			assert.NotNil(t, eventState)
@@ -151,6 +160,7 @@ func TestFromFile(t *testing.T) {
 			assert.Equal(t, "test_token", bearerProperties)
 		},
 		"./testdata/workflows/applicationrequest.multiauth.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Applicant Request Decision Workflow", w.Name)
 			assert.IsType(t, &model.DataBasedSwitchState{}, w.States[0])
 			eventState := w.States[0].(*model.DataBasedSwitchState)
 			assert.NotNil(t, eventState)
@@ -175,9 +185,9 @@ func TestFromFile(t *testing.T) {
 			basicProperties := w.Auth.Defs[1].Properties.(*model.BasicAuthProperties)
 			assert.Equal(t, "test_user", basicProperties.Username)
 			assert.Equal(t, "test_pwd", basicProperties.Password)
-
 		},
 		"./testdata/workflows/applicationrequest.rp.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Applicant Request Decision Workflow", w.Name)
 			assert.IsType(t, &model.DataBasedSwitchState{}, w.States[0])
 			eventState := w.States[0].(*model.DataBasedSwitchState)
 			assert.NotNil(t, eventState)
@@ -194,6 +204,7 @@ func TestFromFile(t *testing.T) {
 			assert.Equal(t, "TimeoutRetryStrategy", w.Retries[0].Name)
 		},
 		"./testdata/workflows/checkinbox.sw.yaml": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Check Inbox Workflow", w.Name)
 			assert.IsType(t, &model.OperationState{}, w.States[0])
 			operationState := w.States[0].(*model.OperationState)
 			assert.NotNil(t, operationState)
@@ -202,6 +213,7 @@ func TestFromFile(t *testing.T) {
 		},
 		// validates: https://github.com/serverlessworkflow/specification/pull/175/
 		"./testdata/workflows/provisionorders.sw.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Provision Orders", w.Name)
 			assert.IsType(t, &model.OperationState{}, w.States[0])
 			operationState := w.States[0].(*model.OperationState)
 			assert.NotNil(t, operationState)
@@ -213,12 +225,16 @@ func TestFromFile(t *testing.T) {
 			assert.Equal(t, "MissingItem", operationState.OnErrors[1].Transition.NextState)
 			assert.Equal(t, "Missing order quantity", operationState.OnErrors[2].ErrorRef)
 			assert.Equal(t, "MissingQuantity", operationState.OnErrors[2].Transition.NextState)
-		}, "./testdata/workflows/checkinbox.cron-test.sw.yaml": func(t *testing.T, w *model.Workflow) {
+		},
+		"./testdata/workflows/checkinbox.cron-test.sw.yaml": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Check Inbox Workflow", w.Name)
 			assert.Equal(t, "0 0/15 * * * ?", w.Start.Schedule.Cron.Expression)
 			assert.Equal(t, "checkInboxFunction", w.States[0].(*model.OperationState).Actions[0].FunctionRef.RefName)
 			assert.Equal(t, "SendTextForHighPriority", w.States[0].GetTransition().NextState)
 			assert.False(t, w.States[1].GetEnd().Terminate)
-		}, "./testdata/workflows/applicationrequest-issue16.sw.yaml": func(t *testing.T, w *model.Workflow) {
+		},
+		"./testdata/workflows/applicationrequest-issue16.sw.yaml": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Applicant Request Decision Workflow", w.Name)
 			assert.IsType(t, &model.DataBasedSwitchState{}, w.States[0])
 			dataBaseSwitchState := w.States[0].(*model.DataBasedSwitchState)
 			assert.NotNil(t, dataBaseSwitchState)
@@ -227,6 +243,7 @@ func TestFromFile(t *testing.T) {
 		},
 		// validates: https://github.com/serverlessworkflow/sdk-go/issues/36
 		"./testdata/workflows/patientonboarding.sw.yaml": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Patient Onboarding Workflow", w.Name)
 			assert.IsType(t, &model.EventState{}, w.States[0])
 			eventState := w.States[0].(*model.EventState)
 			assert.NotNil(t, eventState)
@@ -236,26 +253,32 @@ func TestFromFile(t *testing.T) {
 			assert.Equal(t, float32(1.1), w.Retries[0].Multiplier.FloatVal)
 		},
 		"./testdata/workflows/greetings-secret.sw.yaml": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Greeting Workflow", w.Name)
 			assert.Len(t, w.Secrets, 1)
 		},
 		"./testdata/workflows/greetings-secret-file.sw.yaml": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Greeting Workflow", w.Name)
 			assert.Len(t, w.Secrets, 3)
 		},
 		"./testdata/workflows/greetings-constants-file.sw.yaml": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Greeting Workflow", w.Name)
 			assert.NotEmpty(t, w.Constants)
 			assert.NotEmpty(t, w.Constants.Data["Translations"])
 		},
 		"./testdata/workflows/roomreadings.timeouts.sw.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Room Temp and Humidity Workflow", w.Name)
 			assert.NotNil(t, w.Timeouts)
 			assert.Equal(t, "PT1H", w.Timeouts.WorkflowExecTimeout.Duration)
 			assert.Equal(t, "GenerateReport", w.Timeouts.WorkflowExecTimeout.RunBefore)
 		},
 		"./testdata/workflows/roomreadings.timeouts.file.sw.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Room Temp and Humidity Workflow", w.Name)
 			assert.NotNil(t, w.Timeouts)
 			assert.Equal(t, "PT1H", w.Timeouts.WorkflowExecTimeout.Duration)
 			assert.Equal(t, "GenerateReport", w.Timeouts.WorkflowExecTimeout.RunBefore)
 		},
 		"./testdata/workflows/purchaseorderworkflow.sw.json": func(t *testing.T, w *model.Workflow) {
+			assert.Equal(t, "Purchase Order Workflow", w.Name)
 			assert.NotNil(t, w.Timeouts)
 			assert.Equal(t, "PT30D", w.Timeouts.WorkflowExecTimeout.Duration)
 			assert.Equal(t, "CancelOrder", w.Timeouts.WorkflowExecTimeout.RunBefore)

--- a/parser/testdata/workflows/greetings-v08-spec.sw.yaml
+++ b/parser/testdata/workflows/greetings-v08-spec.sw.yaml
@@ -14,7 +14,6 @@
 
 id: custom.greeting
 version: '1.0'
-name: Greeting Workflow
 description: Greet Someone
 specVersion: "0.8"
 start:


### PR DESCRIPTION
Signed-off-by: spolti <filippespolti@gmail.com>
issue: https://github.com/serverlessworkflow/sdk-go/issues/70

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

**Special notes for reviewers**:

**Additional information (if needed):**
