### PR TITLE
feat(*): add v0.8 action data filter's useResults field

### DIFF
--- a/model/action.go
+++ b/model/action.go
@@ -1,0 +1,106 @@
+// Copyright 2022 The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+)
+
+// Action ...
+type Action struct {
+	// Unique action definition name
+	Name        string       `json:"name,omitempty"`
+	FunctionRef *FunctionRef `json:"functionRef,omitempty"`
+	// References a 'trigger' and 'result' reusable event definitions
+	EventRef *EventRef `json:"eventRef,omitempty"`
+	// References a sub-workflow to be executed
+	SubFlowRef *WorkflowRef `json:"subFlowRef,omitempty"`
+	// Sleep Defines time period workflow execution should sleep before / after function execution
+	Sleep Sleep `json:"sleep,omitempty"`
+	// RetryRef References a defined workflow retry definition. If not defined the default retry policy is assumed
+	RetryRef string `json:"retryRef,omitempty"`
+	// List of unique references to defined workflow errors for which the action should not be retried. Used only when `autoRetries` is set to `true`
+	NonRetryableErrors []string `json:"nonRetryableErrors,omitempty" validate:"omitempty,min=1"`
+	// List of unique references to defined workflow errors for which the action should be retried. Used only when `autoRetries` is set to `false`
+	RetryableErrors []string `json:"retryableErrors,omitempty" validate:"omitempty,min=1"`
+	// Action data filter
+	ActionDataFilter ActionDataFilter `json:"actionDataFilter,omitempty"`
+}
+
+// FunctionRef ...
+type FunctionRef struct {
+	// Name of the referenced function
+	RefName string `json:"refName" validate:"required"`
+	// Function arguments
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
+	// String containing a valid GraphQL selection set
+	SelectionSet string `json:"selectionSet,omitempty"`
+}
+
+// UnmarshalJSON ...
+func (f *FunctionRef) UnmarshalJSON(data []byte) error {
+	funcRef := make(map[string]interface{})
+	if err := json.Unmarshal(data, &funcRef); err != nil {
+		f.RefName, err = unmarshalString(data)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	f.RefName = requiresNotNilOrEmpty(funcRef["refName"])
+	if _, found := funcRef["arguments"]; found {
+		f.Arguments = funcRef["arguments"].(map[string]interface{})
+	}
+	f.SelectionSet = requiresNotNilOrEmpty(funcRef["selectionSet"])
+
+	return nil
+}
+
+// WorkflowRef holds a reference for a workflow definition
+type WorkflowRef struct {
+	// Sub-workflow unique id
+	WorkflowID string `json:"workflowId" validate:"required"`
+	// Sub-workflow version
+	Version string `json:"version,omitempty"`
+}
+
+// UnmarshalJSON ...
+func (s *WorkflowRef) UnmarshalJSON(data []byte) error {
+	subflowRef := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &subflowRef); err != nil {
+		s.WorkflowID, err = unmarshalString(data)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	if err := unmarshalKey("version", subflowRef, &s.Version); err != nil {
+		return err
+	}
+	if err := unmarshalKey("workflowId", subflowRef, &s.WorkflowID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Sleep ...
+type Sleep struct {
+	// Before Amount of time (ISO 8601 duration format) to sleep before function/subflow invocation. Does not apply if 'eventRef' is defined.
+	Before string `json:"before,omitempty"`
+	// After Amount of time (ISO 8601 duration format) to sleep after function/subflow invocation. Does not apply if 'eventRef' is defined.
+	After string `json:"after,omitempty"`
+}

--- a/model/action_data_filter.go
+++ b/model/action_data_filter.go
@@ -1,0 +1,57 @@
+// Copyright 2022 The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// ActionDataFilter used to filter action data results.
+type ActionDataFilter struct {
+	// Workflow expression that selects state data that the state action can use
+	FromStateData string `json:"fromStateData,omitempty"`
+
+	// UseResults represent where action data results is added/merged to state data. If it's false, results & toStateData should be ignored.
+	// Defaults to true.
+	UseResults bool `json:"useResults,omitempty"`
+
+	// Workflow expression that filters the actions' data results
+	Results string `json:"results,omitempty"`
+	// Workflow expression that selects a state data element to which the action results should be added/merged into. If not specified, denote, the top-level state data element
+	ToStateData string `json:"toStateData,omitempty"`
+}
+
+type actionDataFilterForUnmarshal ActionDataFilter
+
+func (f *ActionDataFilter) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 {
+		return fmt.Errorf("no bytes to unmarshal")
+	}
+
+	v := actionDataFilterForUnmarshal{
+		UseResults: true,
+	}
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		// TODO: replace the error message with correct type's name
+		return err
+	}
+
+	*f = ActionDataFilter(v)
+	return nil
+}

--- a/model/action_data_filter_test.go
+++ b/model/action_data_filter_test.go
@@ -1,0 +1,83 @@
+// Copyright 2022 The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActionDataFilterUnmarshalJSON(t *testing.T) {
+	type testCase struct {
+		desp   string
+		data   string
+		expect ActionDataFilter
+		err    string
+	}
+	testCases := []testCase{
+		{
+			desp: "normal test",
+			data: `{"fromStateData": "1", "results": "2", "toStateData": "3"}`,
+			expect: ActionDataFilter{
+				FromStateData: "1",
+				Results:       "2",
+				ToStateData:   "3",
+				UseResults:    true,
+			},
+			err: ``,
+		},
+		{
+			desp: "add UseData to false",
+			data: `{"fromStateData": "1", "results": "2", "toStateData": "3", "useResults": false}`,
+			expect: ActionDataFilter{
+				FromStateData: "1",
+				Results:       "2",
+				ToStateData:   "3",
+				UseResults:    false,
+			},
+			err: ``,
+		},
+		{
+			desp:   "empty data",
+			data:   ` `,
+			expect: ActionDataFilter{},
+			err:    `unexpected end of JSON input`,
+		},
+		{
+			desp:   "invalid json format",
+			data:   `{"fromStateData": 1, "results": "2", "toStateData": "3"}`,
+			expect: ActionDataFilter{},
+			err:    `json: cannot unmarshal number into Go struct field actionDataFilterForUnmarshal.fromStateData of type string`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desp, func(t *testing.T) {
+			var v ActionDataFilter
+			err := json.Unmarshal([]byte(tc.data), &v)
+
+			if tc.err != "" {
+				assert.Error(t, err)
+				assert.Regexp(t, tc.err, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expect, v)
+		})
+	}
+}

--- a/model/action_test.go
+++ b/model/action_test.go
@@ -1,0 +1,15 @@
+// Copyright 2022 The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model

--- a/model/function.go
+++ b/model/function.go
@@ -14,8 +14,6 @@
 
 package model
 
-import "encoding/json"
-
 const (
 	// FunctionTypeREST ...
 	FunctionTypeREST FunctionType = "rest"
@@ -45,34 +43,4 @@ type Function struct {
 	Type FunctionType `json:"type,omitempty"`
 	// References an auth definition name to be used to access to resource defined in the operation parameter
 	AuthRef string `json:"authRef,omitempty" validate:"omitempty,min=1"`
-}
-
-// FunctionRef ...
-type FunctionRef struct {
-	// Name of the referenced function
-	RefName string `json:"refName" validate:"required"`
-	// Function arguments
-	Arguments map[string]interface{} `json:"arguments,omitempty"`
-	// String containing a valid GraphQL selection set
-	SelectionSet string `json:"selectionSet,omitempty"`
-}
-
-// UnmarshalJSON ...
-func (f *FunctionRef) UnmarshalJSON(data []byte) error {
-	funcRef := make(map[string]interface{})
-	if err := json.Unmarshal(data, &funcRef); err != nil {
-		f.RefName, err = unmarshalString(data)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
-	f.RefName = requiresNotNilOrEmpty(funcRef["refName"])
-	if _, found := funcRef["arguments"]; found {
-		f.Arguments = funcRef["arguments"].(map[string]interface{})
-	}
-	f.SelectionSet = requiresNotNilOrEmpty(funcRef["selectionSet"])
-
-	return nil
 }

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -206,34 +206,6 @@ func (w *Workflow) setDefaults() {
 	}
 }
 
-// WorkflowRef holds a reference for a workflow definition
-type WorkflowRef struct {
-	// Sub-workflow unique id
-	WorkflowID string `json:"workflowId" validate:"required"`
-	// Sub-workflow version
-	Version string `json:"version,omitempty"`
-}
-
-// UnmarshalJSON ...
-func (s *WorkflowRef) UnmarshalJSON(data []byte) error {
-	subflowRef := make(map[string]json.RawMessage)
-	if err := json.Unmarshal(data, &subflowRef); err != nil {
-		s.WorkflowID, err = unmarshalString(data)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-	if err := unmarshalKey("version", subflowRef, &s.Version); err != nil {
-		return err
-	}
-	if err := unmarshalKey("workflowId", subflowRef, &s.WorkflowID); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // Timeouts ...
 type Timeouts struct {
 	// WorkflowExecTimeout Workflow execution timeout duration (ISO 8601 duration format). If not specified should be 'unlimited'
@@ -474,27 +446,6 @@ type OnEvents struct {
 	EventDataFilter EventDataFilter `json:"eventDataFilter,omitempty"`
 }
 
-// Action ...
-type Action struct {
-	// Unique action definition name
-	Name        string       `json:"name,omitempty"`
-	FunctionRef *FunctionRef `json:"functionRef,omitempty"`
-	// References a 'trigger' and 'result' reusable event definitions
-	EventRef *EventRef `json:"eventRef,omitempty"`
-	// References a sub-workflow to be executed
-	SubFlowRef *WorkflowRef `json:"subFlowRef,omitempty"`
-	// Sleep Defines time period workflow execution should sleep before / after function execution
-	Sleep Sleep `json:"sleep,omitempty"`
-	// RetryRef References a defined workflow retry definition. If not defined the default retry policy is assumed
-	RetryRef string `json:"retryRef,omitempty"`
-	// List of unique references to defined workflow errors for which the action should not be retried. Used only when `autoRetries` is set to `true`
-	NonRetryableErrors []string `json:"nonRetryableErrors,omitempty" validate:"omitempty,min=1"`
-	// List of unique references to defined workflow errors for which the action should be retried. Used only when `autoRetries` is set to `false`
-	RetryableErrors []string `json:"retryableErrors,omitempty" validate:"omitempty,min=1"`
-	// Action data filter
-	ActionDataFilter ActionDataFilter `json:"actionDataFilter,omitempty"`
-}
-
 // End definition
 type End struct {
 	// If true, completes all execution flows in the given workflow instance
@@ -578,16 +529,6 @@ type BranchTimeouts struct {
 	BranchExecTimeout string `json:"branchExecTimeout,omitempty" validate:"omitempty,min=1"`
 }
 
-// ActionDataFilter ...
-type ActionDataFilter struct {
-	// Workflow expression that selects state data that the state action can use
-	FromStateData string `json:"fromStateData,omitempty"`
-	// Workflow expression that filters the actions' data results
-	Results string `json:"results,omitempty"`
-	// Workflow expression that selects a state data element to which the action results should be added/merged into. If not specified, denote, the top-level state data element
-	ToStateData string `json:"toStateData,omitempty"`
-}
-
 // DataInputSchema ...
 type DataInputSchema struct {
 	Schema                 string `json:"schema" validate:"required"`
@@ -655,12 +596,4 @@ func (c *Constants) UnmarshalJSON(data []byte) error {
 	}
 	c.Data = constantData
 	return nil
-}
-
-// Sleep ...
-type Sleep struct {
-	// Before Amount of time (ISO 8601 duration format) to sleep before function/subflow invocation. Does not apply if 'eventRef' is defined.
-	Before string `json:"before,omitempty"`
-	// After Amount of time (ISO 8601 duration format) to sleep after function/subflow invocation. Does not apply if 'eventRef' is defined.
-	After string `json:"after,omitempty"`
 }

--- a/parser/testdata/workflows/greetings-constants-file.sw.yaml
+++ b/parser/testdata/workflows/greetings-constants-file.sw.yaml
@@ -33,7 +33,7 @@ states:
           parameters:
             name: "${ SECRETS | .SECRET1 }"
         actionDataFilter:
-          dataResultsPath: "${ .payload | .greeting }"
+          toStateData: "${ .payload | .greeting }"
     stateDataFilter:
       dataOutputPath: "${ .greeting }"
     end:

--- a/parser/testdata/workflows/greetings-secret-file.sw.yaml
+++ b/parser/testdata/workflows/greetings-secret-file.sw.yaml
@@ -33,7 +33,7 @@ states:
           parameters:
             name: "${ .SECRETS | .SECRET1 }"
         actionDataFilter:
-          dataResultsPath: "${ .payload | .greeting }"
+          toStateData: "${ .payload | .greeting }"
     stateDataFilter:
       dataOutputPath: "${ .greeting }"
     end:

--- a/parser/testdata/workflows/greetings-secret.sw.yaml
+++ b/parser/testdata/workflows/greetings-secret.sw.yaml
@@ -34,7 +34,7 @@ states:
           parameters:
             name: "${ .SECRETS | .NAME }"
         actionDataFilter:
-          dataResultsPath: "${ .payload | .greeting }"
+          toStateData: "${ .payload | .greeting }"
     stateDataFilter:
       dataOutputPath: "${ .greeting }"
     end:

--- a/parser/testdata/workflows/greetings.sw.json
+++ b/parser/testdata/workflows/greetings.sw.json
@@ -26,7 +26,7 @@
             }
           },
           "actionDataFilter": {
-            "dataResultsPath": "${ .greeting }"
+            "toStateData": "${ .greeting }"
           }
         }
       ],

--- a/parser/testdata/workflows/greetings.sw.yaml
+++ b/parser/testdata/workflows/greetings.sw.yaml
@@ -32,7 +32,7 @@ states:
           parameters:
             name: "${ .greet | .name }"
         actionDataFilter:
-          dataResultsPath: "${ .payload | .greeting }"
+          toStateData: "${ .payload | .greeting }"
     stateDataFilter:
       dataOutputPath: "${ .greeting }"
     end:

--- a/parser/testdata/workflows/greetings_sleep.sw.json
+++ b/parser/testdata/workflows/greetings_sleep.sw.json
@@ -34,7 +34,7 @@
               }
             },
             "actionDataFilter": {
-              "dataResultsPath": "${ .greeting }"
+              "toStateData": "${ .greeting }"
             }
           }
         ],


### PR DESCRIPTION
Signed-off-by: lsytj0413 <511121939@qq.com>

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- add v0.8 actionDataFilter.useResults field

**Special notes for reviewers**:

**Additional information (if needed):**

Refs: https://github.com/serverlessworkflow/sdk-go/issues/70
