### PR TITLE
v08 spec alignment - Workflow start no longer a required property

### DIFF
--- a/model/workflow.go
+++ b/model/workflow.go
@@ -63,7 +63,7 @@ type BaseWorkflow struct {
 	Description string `json:"description,omitempty"`
 	// Workflow version
 	Version string `json:"version" validate:"omitempty,min=1"`
-	Start   *Start `json:"start" validate:"required"`
+	Start   *Start `json:"start" validate:"omitempty"`
 	// Annotations List of helpful terms describing the workflows intended purpose, subject areas, or other important qualities
 	Annotations []string `json:"annotations,omitempty"`
 	// DataInputSchema URI of the JSON Schema used to validate the workflow data input

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -63,7 +63,7 @@ type BaseWorkflow struct {
 	Description string `json:"description,omitempty"`
 	// Workflow version
 	Version string `json:"version" validate:"omitempty,min=1"`
-	Start   *Start `json:"start" validate:"omitempty"`
+	Start   *Start `json:"start,omitempty"`
 	// Annotations List of helpful terms describing the workflows intended purpose, subject areas, or other important qualities
 	Annotations []string `json:"annotations,omitempty"`
 	// DataInputSchema URI of the JSON Schema used to validate the workflow data input

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -68,6 +68,7 @@ func TestFromFile(t *testing.T) {
 		},
 		"./testdata/workflows/greetings-v08-spec.sw.yaml": func(t *testing.T, w *model.Workflow) {
 			assert.Empty(t, w.Name)
+			assert.Empty(t, w.Start)
 			assert.IsType(t, &model.OperationState{}, w.States[0])
 			assert.Equal(t, "custom.greeting", w.ID)
 			assert.NotEmpty(t, w.States[0].(*model.OperationState).Actions)

--- a/parser/testdata/workflows/greetings-v08-spec.sw.yaml
+++ b/parser/testdata/workflows/greetings-v08-spec.sw.yaml
@@ -16,8 +16,6 @@ id: custom.greeting
 version: '1.0'
 description: Greet Someone
 specVersion: "0.8"
-start:
-  stateName: Greet
 functions:
   - name: greetingCustomFunction
     operation: /path/to/my/script/greeting.ts#CustomGreeting


### PR DESCRIPTION
Signed-off-by: spolti <filippespolti@gmail.com>
Fixes: https://github.com/serverlessworkflow/sdk-go/issues/70

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

**Special notes for reviewers**:

**Additional information (if needed):**
