### PR TITLE
fix(*): parallelState with completeType defaults to allOf

### DIFF
--- a/model/parallel_state.go
+++ b/model/parallel_state.go
@@ -1,0 +1,134 @@
+// Copyright 2022 The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	validator "github.com/go-playground/validator/v10"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	val "github.com/serverlessworkflow/sdk-go/v2/validator"
+)
+
+// CompletionType define on how to complete branch execution.
+type CompletionType string
+
+const (
+	// CompletionTypeAllOf defines all branches must complete execution before the state can transition/end.
+	CompletionTypeAllOf CompletionType = "allOf"
+	// CompletionTypeAtLeast defines state can transition/end once at least the specified number of branches
+	// have completed execution.
+	CompletionTypeAtLeast CompletionType = "atLeast"
+)
+
+// ParallelState Consists of a number of states that are executed in parallel
+type ParallelState struct {
+	BaseState
+	// Branch Definitions
+	Branches []Branch `json:"branches" validate:"required,min=1,dive"`
+	// Option types on how to complete branch execution.
+	// Defaults to `allOf`
+	CompletionType CompletionType `json:"completionType,omitempty" validate:"required,oneof=allOf atLeast"`
+
+	// Used when completionType is set to 'atLeast' to specify the minimum number of branches that must complete before the state will transition."
+	// TODO: change this field to unmarshal result as int
+	NumCompleted intstr.IntOrString `json:"numCompleted,omitempty"`
+	// State specific timeouts
+	Timeouts *ParallelStateTimeout `json:"timeouts,omitempty"`
+}
+
+type parallelStateForUnmarshal ParallelState
+
+// UnmarshalJSON unmarshal ParallelState object from json bytes
+func (s *ParallelState) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		// TODO: Normalize error messages
+		return fmt.Errorf("no bytes to unmarshal")
+	}
+
+	v := &parallelStateForUnmarshal{
+		CompletionType: CompletionTypeAllOf,
+	}
+	err := json.Unmarshal(b, v)
+	if err != nil {
+		return err
+	}
+
+	*s = ParallelState(*v)
+
+	return nil
+}
+
+// Branch Definition
+type Branch struct {
+	// Branch name
+	Name string `json:"name" validate:"required"`
+	// Actions to be executed in this branch
+	Actions []Action `json:"actions" validate:"required,min=1,dive"`
+	// Timeouts State specific timeouts
+	Timeouts *BranchTimeouts `json:"timeouts,omitempty"`
+}
+
+// BranchTimeouts defines the specific timeout settings for branch
+type BranchTimeouts struct {
+	// ActionExecTimeout Single actions definition execution timeout duration (ISO 8601 duration format)
+	ActionExecTimeout string `json:"actionExecTimeout,omitempty" validate:"omitempty,iso8601duration"`
+	// BranchExecTimeout Single branch execution timeout duration (ISO 8601 duration format)
+	BranchExecTimeout string `json:"branchExecTimeout,omitempty" validate:"omitempty,iso8601duration"`
+}
+
+// ParallelStateTimeout defines the specific timeout settings for parallel state
+type ParallelStateTimeout struct {
+	StateExecTimeout  *StateExecTimeout `json:"stateExecTimeout,omitempty"`
+	BranchExecTimeout string            `json:"branchExecTimeout,omitempty" validate:"omitempty,iso8601duration"`
+}
+
+// ParallelStateStructLevelValidation custom validator for ParallelState
+func ParallelStateStructLevelValidation(_ context.Context, structLevel validator.StructLevel) {
+	parallelStateObj := structLevel.Current().Interface().(ParallelState)
+
+	if parallelStateObj.CompletionType == CompletionTypeAllOf {
+		return
+	}
+
+	switch parallelStateObj.NumCompleted.Type {
+	case intstr.Int:
+		if parallelStateObj.NumCompleted.IntVal <= 0 {
+			structLevel.ReportError(reflect.ValueOf(parallelStateObj.NumCompleted), "NumCompleted", "numCompleted", "gt0", "")
+		}
+	case intstr.String:
+		v, err := strconv.Atoi(parallelStateObj.NumCompleted.StrVal)
+		if err != nil {
+			structLevel.ReportError(reflect.ValueOf(parallelStateObj.NumCompleted), "NumCompleted", "numCompleted", "gt0", err.Error())
+			return
+		}
+
+		if v <= 0 {
+			structLevel.ReportError(reflect.ValueOf(parallelStateObj.NumCompleted), "NumCompleted", "numCompleted", "gt0", "")
+		}
+	}
+}
+
+func init() {
+	val.GetValidator().RegisterStructValidationCtx(
+		ParallelStateStructLevelValidation,
+		ParallelState{},
+	)
+}

--- a/model/parallel_state_test.go
+++ b/model/parallel_state_test.go
@@ -1,0 +1,191 @@
+// Copyright 2022 The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	val "github.com/serverlessworkflow/sdk-go/v2/validator"
+)
+
+func TestParallelStateUnmarshalJSON(t *testing.T) {
+	type testCase struct {
+		desp   string
+		data   string
+		expect *ParallelState
+		err    string
+	}
+	testCases := []testCase{
+		{
+			desp: "all field set",
+			data: `{"completionType": "allOf", "numCompleted": 1}`,
+			expect: &ParallelState{
+				CompletionType: CompletionTypeAllOf,
+				NumCompleted:   intstr.FromInt(1),
+			},
+			err: ``,
+		},
+		{
+			desp: "all optional field not set",
+			data: `{"numCompleted": 1}`,
+			expect: &ParallelState{
+				CompletionType: CompletionTypeAllOf,
+				NumCompleted:   intstr.FromInt(1),
+			},
+			err: ``,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desp, func(t *testing.T) {
+			var v ParallelState
+			err := json.Unmarshal([]byte(tc.data), &v)
+
+			if tc.err != "" {
+				assert.Error(t, err)
+				assert.Regexp(t, tc.err, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expect, &v)
+		})
+	}
+}
+
+func TestParallelStateStructLevelValidation(t *testing.T) {
+	type testCase struct {
+		desp  string
+		state *ParallelState
+		err   string
+	}
+	testCases := []testCase{
+		{
+			desp: "normal",
+			state: &ParallelState{
+				BaseState: BaseState{
+					Name: "1",
+					Type: "parallel",
+				},
+				Branches: []Branch{
+					{
+						Name: "b1",
+						Actions: []Action{
+							{},
+						},
+					},
+				},
+				CompletionType: CompletionTypeAllOf,
+				NumCompleted:   intstr.FromInt(1),
+			},
+			err: ``,
+		},
+		{
+			desp: "invalid completeType",
+			state: &ParallelState{
+				BaseState: BaseState{
+					Name: "1",
+					Type: "parallel",
+				},
+				Branches: []Branch{
+					{
+						Name: "b1",
+						Actions: []Action{
+							{},
+						},
+					},
+				},
+				CompletionType: CompletionTypeAllOf + "1",
+			},
+			err: `Key: 'ParallelState.CompletionType' Error:Field validation for 'CompletionType' failed on the 'oneof' tag`,
+		},
+		{
+			desp: "invalid numCompleted `int`",
+			state: &ParallelState{
+				BaseState: BaseState{
+					Name: "1",
+					Type: "parallel",
+				},
+				Branches: []Branch{
+					{
+						Name: "b1",
+						Actions: []Action{
+							{},
+						},
+					},
+				},
+				CompletionType: CompletionTypeAtLeast,
+				NumCompleted:   intstr.FromInt(0),
+			},
+			err: `Key: 'ParallelState.NumCompleted' Error:Field validation for 'NumCompleted' failed on the 'gt0' tag`,
+		},
+		{
+			desp: "invalid numCompleted string format",
+			state: &ParallelState{
+				BaseState: BaseState{
+					Name: "1",
+					Type: "parallel",
+				},
+				Branches: []Branch{
+					{
+						Name: "b1",
+						Actions: []Action{
+							{},
+						},
+					},
+				},
+				CompletionType: CompletionTypeAtLeast,
+				NumCompleted:   intstr.FromString("a"),
+			},
+			err: `Key: 'ParallelState.NumCompleted' Error:Field validation for 'NumCompleted' failed on the 'gt0' tag`,
+		},
+		{
+			desp: "normal",
+			state: &ParallelState{
+				BaseState: BaseState{
+					Name: "1",
+					Type: "parallel",
+				},
+				Branches: []Branch{
+					{
+						Name: "b1",
+						Actions: []Action{
+							{},
+						},
+					},
+				},
+				CompletionType: CompletionTypeAtLeast,
+				NumCompleted:   intstr.FromString("0"),
+			},
+			err: `Key: 'ParallelState.NumCompleted' Error:Field validation for 'NumCompleted' failed on the 'gt0' tag`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desp, func(t *testing.T) {
+			err := val.GetValidator().Struct(tc.state)
+
+			if tc.err != "" {
+				assert.Error(t, err)
+				assert.Regexp(t, tc.err, err)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/model/states.go
+++ b/model/states.go
@@ -41,11 +41,6 @@ const (
 	// StateTypeSleep ...
 	StateTypeSleep = "sleep"
 
-	// CompletionTypeAllOf ...
-	CompletionTypeAllOf CompletionType = "allOf"
-	// CompletionTypeAtLeast ...
-	CompletionTypeAtLeast CompletionType = "atLeast"
-
 	// ForEachModeTypeSequential ...
 	ForEachModeTypeSequential ForEachModeType = "sequential"
 	// ForEachModeTypeParallel ...
@@ -81,9 +76,6 @@ func getActionsModelMapping(stateType string, s map[string]interface{}) (State, 
 
 // StateType ...
 type StateType string
-
-// CompletionType Option types on how to complete branch execution.
-type CompletionType string
 
 // ForEachModeType Specifies how iterations are to be performed (sequentially or in parallel)
 type ForEachModeType string
@@ -170,25 +162,6 @@ type OperationState struct {
 type OperationStateTimeout struct {
 	StateExecTimeout  *StateExecTimeout `json:"stateExecTimeout,omitempty"`
 	ActionExecTimeout string            `json:"actionExecTimeout,omitempty" validate:"omitempty,min=1"`
-}
-
-// ParallelState Consists of a number of states that are executed in parallel
-type ParallelState struct {
-	BaseState
-	// Branch Definitions
-	Branches []Branch `json:"branches" validate:"required,min=1,dive"`
-	// Option types on how to complete branch execution.
-	CompletionType CompletionType `json:"completionType,omitempty"`
-	// Used when completionType is set to 'atLeast' to specify the minimum number of branches that must complete before the state will transition."
-	NumCompleted intstr.IntOrString `json:"numCompleted,omitempty"`
-	// State specific timeouts
-	Timeouts *ParallelStateTimeout `json:"timeouts,omitempty"`
-}
-
-// ParallelStateTimeout ...
-type ParallelStateTimeout struct {
-	StateExecTimeout  StateExecTimeout `json:"stateExecTimeout,omitempty"`
-	BranchExecTimeout string           `json:"branchExecTimeout,omitempty" validate:"omitempty,min=1"`
 }
 
 // InjectState ...

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -554,24 +554,6 @@ type StateDataFilter struct {
 	Output string `json:"output,omitempty"`
 }
 
-// Branch Definition
-type Branch struct {
-	// Branch name
-	Name string `json:"name" validate:"required"`
-	// Actions to be executed in this branch
-	Actions []Action `json:"actions" validate:"required,min=1"`
-	// Timeouts State specific timeouts
-	Timeouts *BranchTimeouts `json:"timeouts,omitempty"`
-}
-
-// BranchTimeouts ...
-type BranchTimeouts struct {
-	// ActionExecTimeout Single actions definition execution timeout duration (ISO 8601 duration format)
-	ActionExecTimeout string `json:"actionExecTimeout,omitempty" validate:"omitempty,min=1"`
-	// BranchExecTimeout Single branch execution timeout duration (ISO 8601 duration format)
-	BranchExecTimeout string `json:"branchExecTimeout,omitempty" validate:"omitempty,min=1"`
-}
-
 // DataInputSchema ...
 type DataInputSchema struct {
 	Schema                 string `json:"schema" validate:"required"`


### PR DESCRIPTION
Signed-off-by: lsytj0413 <511121939@qq.com>

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- set ParallelState.CompleteType defaults to allOf
- add validate for ParallelState.NumCompleted

**Special notes for reviewers**:

**Additional information (if needed):**

Fixed https://github.com/serverlessworkflow/sdk-go/issues/108
