### PR TITLE
Add @spolti to the SDK Go maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,5 @@
 # Serverless Workflow Go SDK Maintainers
 
 * [Ricardo Zanini](https://github.com/ricardozanini)
+* [Filippe Spolti](https://github.com/spolti)
+* 

--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
 # List of usernames who may use /lgtm
 reviewers:
 - ricardozanini
+- spolti
 
 # List of usernames who may use /approve
 approvers:


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
This added @spolti as a maintainer of the operator. But still, every PR will need a @serverlessworkflow/core-maintainers approval to be merged.

**Special notes for reviewers**:
@spolti has shown commitment and trust to the past few versions we released, so I'm putting a vote to add him as a maintainer of the SDK.
