### PR TITLE
#181 Skip validTransitionAndEnd for States that are used for compensation

### DIFF
--- a/model/states_validator.go
+++ b/model/states_validator.go
@@ -26,7 +26,7 @@ func init() {
 
 func baseStateStructLevelValidationCtx(ctx ValidatorContext, structLevel validator.StructLevel) {
 	baseState := structLevel.Current().Interface().(BaseState)
-	if baseState.Type != StateTypeSwitch {
+	if baseState.Type != StateTypeSwitch && !baseState.UsedForCompensation {
 		validTransitionAndEnd(structLevel, baseState, baseState.Transition, baseState.End)
 	}
 


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**: This PR fixes issue #181 

**Special notes for reviewers**:
I am skipping Transition and End validate tags for states that are used for compensation as "End" should not be defined and Transition is optional for a state that is used for compensation. 

**Additional information (if needed):
If I missed something please let me know I will fix ASAP
