### PR TITLE
relax state action validation

### DIFF
--- a/hack/deepcopy-gen.sh
+++ b/hack/deepcopy-gen.sh
@@ -43,7 +43,6 @@ if [ "${GENS}" = "all" ] || grep -qw "deepcopy" <<<"${GENS}"; then
   # for debug purposes, increase the log level by updating the -v flag to higher numbers, e.g. -v 4
   "${GOPATH}/bin/deepcopy-gen" -v 1 \
       --input-dirs ./model -O zz_generated.deepcopy \
-      --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.txt" \
-      --output-base ./
+      --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.txt"
       "$@"
 fi

--- a/model/foreach_state.go
+++ b/model/foreach_state.go
@@ -60,8 +60,8 @@ type ForEachState struct {
 	// +optional
 	BatchSize *intstr.IntOrString `json:"batchSize,omitempty"`
 	// Actions to be executed for each of the elements of inputCollection.
-	// +kubebuilder:validation:MinItems=1
-	Actions []Action `json:"actions,omitempty" validate:"required,min=1,dive"`
+	// +kubebuilder:validation:MinItems=0
+	Actions []Action `json:"actions,omitempty" validate:"required,min=0,dive"`
 	// State specific timeout.
 	// +optional
 	Timeouts *ForEachStateTimeout `json:"timeouts,omitempty"`

--- a/model/foreach_state_validator_test.go
+++ b/model/foreach_state_validator_test.go
@@ -108,7 +108,7 @@ workflow.states[0].forEachState.mode is required`,
 				model.States[0].ForEachState.Actions = []Action{}
 				return *model
 			},
-			Err: `workflow.states[0].forEachState.actions must have the minimum 1`,
+			Err: ``,
 		},
 	}
 

--- a/model/operation_state.go
+++ b/model/operation_state.go
@@ -27,8 +27,8 @@ type OperationState struct {
 	// +kubebuilder:default=sequential
 	ActionMode ActionMode `json:"actionMode,omitempty" validate:"required,oneofkind"`
 	// Actions to be performed
-	// +kubebuilder:validation:MinItems=1
-	Actions []Action `json:"actions" validate:"min=1,dive"`
+	// +kubebuilder:validation:MinItems=0
+	Actions []Action `json:"actions" validate:"min=0,dive"`
 	// State specific timeouts
 	// +optional
 	Timeouts *OperationStateTimeout `json:"timeouts,omitempty"`

--- a/model/operation_state_validator_test.go
+++ b/model/operation_state_validator_test.go
@@ -63,7 +63,7 @@ func TestOperationStateStructLevelValidation(t *testing.T) {
 				model.States[0].OperationState.Actions = []Action{}
 				return *model
 			},
-			Err: `workflow.states[0].actions must have the minimum 1`,
+			Err: ``,
 		},
 		{
 			Desp: "oneofkind",


### PR DESCRIPTION
The purpose of this change is to align the workflow validationb between the Java and the GO SDK. Spec allows the action to be a empty list while in the GO SDK, if defined, must have at least one item.

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

**Special notes for reviewers**:

**Additional information (if needed):**
