### PR TITLE
Added CEL to list of valid ExpressionLangs

### DIFF
--- a/model/workflow.go
+++ b/model/workflow.go
@@ -75,6 +75,7 @@ func (i ExpressionLangType) KindValues() []string {
 	return []string{
 		string(JqExpressionLang),
 		string(JsonPathExpressionLang),
+		string(CELExpressionLang),
 	}
 }
 
@@ -88,6 +89,9 @@ const (
 
 	// JsonPathExpressionLang ...
 	JsonPathExpressionLang ExpressionLangType = "jsonpath"
+
+	// CELExpressionLang
+	CELExpressionLang ExpressionLangType = "cel"
 )
 
 // BaseWorkflow describes the partial Workflow definition that does not rely on generic interfaces
@@ -132,7 +136,7 @@ type BaseWorkflow struct {
 	// +optional
 	Constants *Constants `json:"constants,omitempty"`
 	// Identifies the expression language used for workflow expressions. Default is 'jq'.
-	// +kubebuilder:validation:Enum=jq;jsonpath
+	// +kubebuilder:validation:Enum=jq;jsonpath;cel
 	// +kubebuilder:default=jq
 	// +optional
 	ExpressionLang ExpressionLangType `json:"expressionLang,omitempty" validate:"required,oneofkind"`

--- a/model/workflow_validator_test.go
+++ b/model/workflow_validator_test.go
@@ -162,7 +162,7 @@ workflow.key required when "workflow.id" is not defined`,
 				model.BaseWorkflow.ExpressionLang = JqExpressionLang + "invalid"
 				return *model
 			},
-			Err: `workflow.expressionLang need by one of [jq jsonpath]`,
+			Err: `workflow.expressionLang need by one of [jq jsonpath cel]`,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
According to the 0.8 spec, we shouldn't be verifying against a list of "accepted" ExpressionLangs, only that `jq` is the default one.
> Serverless Workflow does not mandate the use of jq and it's possible to use an expression language of your choice with the restriction that a single one must be used for all expressions in a workflow definition. If a different expression language needs to be used, make sure to set the workflow expressionLang property to identify it to runtime implementations.

CEL is a commonly used expression language which sees use in implementations of this `sdk-go` library. Support for it as a valid ExpressionLang was removed in or around 4afc5f310fe575b3108e771c8ae11ddde4308e31.

**Additional information (if needed):**
Optimally, we would want the validation to be more dynamic than adding another language to the list (as I'm doing in this PR), but I do not know enough about the validation processes to present a robust enough solution for that.