### PR TITLE
Removed "required" tag from failOnValidationErrors

### DIFF
--- a/model/workflow.go
+++ b/model/workflow.go
@@ -507,7 +507,8 @@ type DataInputSchema struct {
 	// +kubebuilder:validation:Required
 	Schema string `json:"schema" validate:"required"`
 	// +kubebuilder:validation:Required
-	FailOnValidationErrors bool `json:"failOnValidationErrors" validate:"required"`
+	FailOnValidationErrors bool `json:"failOnValidationErrors"`
+	// FailOnValidationErrors bool `json:"failOnValidationErrors" validate:"required"`
 }
 
 type dataInputSchemaUnmarshal DataInputSchema

--- a/model/workflow_validator_test.go
+++ b/model/workflow_validator_test.go
@@ -417,6 +417,39 @@ Key: 'Workflow.States[3].BaseState.Transition.NextState' Error:Field validation 
 	StructLevelValidationCtx(t, testCases)
 }
 
+func TestDataInputSchemaStructLevelValidation(t *testing.T) {
+	baseWorkflow := buildWorkflow()
+
+	operationState := buildOperationState(baseWorkflow, "start state")
+	buildEndByState(operationState, true, false)
+	action1 := buildActionByOperationState(operationState, "action 1")
+	buildFunctionRef(baseWorkflow, action1, "function 1")
+
+	testCases := []ValidationCase{
+		{
+			Desp: "empty DataInputSchema",
+			Model: func() Workflow {
+				model := baseWorkflow.DeepCopy()
+				model.DataInputSchema = &DataInputSchema{}
+				return *model
+			},
+			Err: `workflow.dataInputSchema.schema is required`,
+		},
+		{
+			Desp: "filled Schema, default failOnValidationErrors",
+			Model: func() Workflow {
+				model := baseWorkflow.DeepCopy()
+				model.DataInputSchema = &DataInputSchema{
+					Schema: "sample schema",
+				}
+				return *model
+			},
+		},
+	}
+
+	StructLevelValidationCtx(t, testCases)
+}
+
 func TestSecretsStructLevelValidation(t *testing.T) {
 	baseWorkflow := buildWorkflow()
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -579,6 +579,13 @@ func TestFromFile(t *testing.T) {
 				assert.Equal(t, "SendTextForHighPriority", w.States[10].SwitchState.DefaultCondition.Transition.NextState)
 				assert.Equal(t, true, w.States[10].End.Terminate)
 			},
+		}, {
+			"./testdata/workflows/dataInputSchemaValidation.yaml", func(t *testing.T, w *model.Workflow) {
+				assert.NotNil(t, w.DataInputSchema)
+
+				assert.Equal(t, "sample schema", w.DataInputSchema.Schema)
+				assert.Equal(t, false, w.DataInputSchema.FailOnValidationErrors)
+			},
 		},
 	}
 	for _, file := range files {

--- a/parser/testdata/workflows/dataInputSchemaValidation.yaml
+++ b/parser/testdata/workflows/dataInputSchemaValidation.yaml
@@ -1,0 +1,28 @@
+# Copyright 2023 The Serverless Workflow Specification Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: Valid DataInputSchema
+version: '1.0'
+specVersion: '0.8'
+start: Start
+dataInputSchema:
+  failOnValidationErrors: false
+  schema: "sample schema"
+states:
+- name: Start
+  type: inject
+  data:
+    done: true
+  end:
+    terminate: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Using the "required" tag on the `DataInputSchema.FailOnValidationErrors` field operates counter-intuitively to the go-playground docs. This also causes workflows to fail validation when the value of the field is manually set to `false` because the validator interprets this as the default/unset value.

**Special notes for reviewers**:
Not sure where to add a test for this case, need some insight on that front.

**Additional information (if needed):**
Go-playground doc reference: https://pkg.go.dev/github.com/go-playground/validator/v10#hdr-Required
> This validates that the value is not the data types default zero value. For numbers ensures value is not zero. For strings ensures value is not "". For slices, maps, pointers, interfaces, channels and functions ensures the value is not nil. For structs ensures value is not the zero value when using WithRequiredStructEnabled.