### PR TITLE
fix: ISO8601 duration wouldn't parse for valid fractional values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/pkg/errors v0.9.1
 	github.com/relvacode/iso8601 v1.3.0
-	github.com/senseyeio/duration v0.0.0-20180430131211-7c2a214ada46
+	github.com/sosodev/duration v1.2.0
 	github.com/stretchr/testify v1.8.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.26.2

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/relvacode/iso8601 v1.3.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
-github.com/senseyeio/duration v0.0.0-20180430131211-7c2a214ada46 h1:Dz0HrI1AtNSGCE8LXLLqoZU4iuOJXPWndenCsZfstA8=
-github.com/senseyeio/duration v0.0.0-20180430131211-7c2a214ada46/go.mod h1:is8FVkzSi7PYLWEXT5MgWhglFsyyiW8ffxAoJqfuFZo=
+github.com/sosodev/duration v1.2.0 h1:pqK/FLSjsAADWY74SyWDCjOcd5l7H8GSnnOGEB9A1Us=
+github.com/sosodev/duration v1.2.0/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 
 	"github.com/relvacode/iso8601"
-	"github.com/senseyeio/duration"
+	"github.com/sosodev/duration"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	validator "github.com/go-playground/validator/v10"
@@ -60,7 +60,7 @@ func GetValidator() *validator.Validate {
 
 // ValidateISO8601TimeDuration validate the string is iso8601 duration format
 func ValidateISO8601TimeDuration(s string) error {
-	_, err := duration.ParseISO8601(s)
+	_, err := duration.Parse(s)
 	return err
 }
 

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -16,6 +16,7 @@ package validator
 
 import (
 	"context"
+	"errors"
 	"strconv"
 
 	"github.com/relvacode/iso8601"
@@ -60,7 +61,13 @@ func GetValidator() *validator.Validate {
 
 // ValidateISO8601TimeDuration validate the string is iso8601 duration format
 func ValidateISO8601TimeDuration(s string) error {
+	if s == "" {
+		return errors.New("could not parse duration string")
+	}
 	_, err := duration.Parse(s)
+	if err != nil {
+		return errors.New("could not parse duration string")
+	}
 	return err
 }
 

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -39,6 +39,11 @@ func TestValidateISO8601TimeDuration(t *testing.T) {
 			err:  ``,
 		},
 		{
+			desp: "fractional_second_designator",
+			s:    "PT0.5S",
+			err:  ``,
+		},
+		{
 			desp: "empty value",
 			s:    "",
 			err:  `could not parse duration string`,


### PR DESCRIPTION
Previously, the library utilized a parsing library for ISO8601 durations that parsed durations into integers only. This caused issues with durations containing fractional values, such as "PT0.5S", which are valid ISO8601 strings but failed to parse due to the limitation of the previous library. 

In this commit, I've replaced the outdated parsing library with a more robust alternative. 

The new library properly handles fractional values, ensuring accurate parsing of ISO8601 duration strings, including cases like "PT0.5S". This update enhances the functionality and reliability of the library by accommodating a broader range of ISO8601 duration formats. Additionally, it ensures compatibility with modern standards and improves the overall usability of the library.
