### PR TITLE
Pin deepcopy version

### DIFF
--- a/hack/deepcopy-gen.sh
+++ b/hack/deepcopy-gen.sh
@@ -32,7 +32,8 @@ shift 1
   # make sure your GOPATH env is properly set.
   # it will go under $GOPATH/bin
   cd "$(dirname "${0}")"
-  GO111MODULE=on go install k8s.io/code-generator/cmd/deepcopy-gen@latest
+  DEEPCOPY_VERSION="v0.29.4"
+  GO111MODULE=on go install k8s.io/code-generator/cmd/deepcopy-gen@${DEEPCOPY_VERSION}
 )
 
 function codegen::join() { local IFS="$1"; shift; echo "$*"; }


### PR DESCRIPTION
chore: Fix go: k8s.io/code-generator/cmd/deepcopy-gen@latest (in k8s.io/code-generator@v0.30.0): go.mod:5: invalid go version '1.22.0': must match format 1.23

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

**Special notes for reviewers**:

**Additional information (if needed):**
