### PR TITLE
use go 1.22.0 instead of 1.22.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/serverlessworkflow/sdk-go/v2
 
-go 1.22.8
+go 1.22.0
 
 toolchain go1.23.1
 


### PR DESCRIPTION
We can't use patch versions in mod files otherwise it may compromise client code.
