### PR TITLE
Refactoring run method

### DIFF
--- a/impl/runner.go
+++ b/impl/runner.go
@@ -137,7 +137,7 @@ func (wr *workflowRunnerImpl) Run(input interface{}) (output interface{}, err er
 	wr.RunnerCtx.SetInput(input)
 	// Run tasks sequentially
 	wr.RunnerCtx.SetStatus(ctx.RunningStatus)
-	doRunner, err := NewDoTaskRunner(wr.Workflow.Do, wr.GetWorkflowDef())
+	doRunner, err := NewDoTaskRunner(wr.Workflow.Do)
 	if err != nil {
 		return nil, err
 	}

--- a/impl/runner.go
+++ b/impl/runner.go
@@ -137,12 +137,12 @@ func (wr *workflowRunnerImpl) Run(input interface{}) (output interface{}, err er
 	wr.RunnerCtx.SetInput(input)
 	// Run tasks sequentially
 	wr.RunnerCtx.SetStatus(ctx.RunningStatus)
-	doRunner, err := NewDoTaskRunner(wr.Workflow.Do, wr)
+	doRunner, err := NewDoTaskRunner(wr.Workflow.Do, wr.GetWorkflowDef())
 	if err != nil {
 		return nil, err
 	}
 	wr.RunnerCtx.SetStartedAt(time.Now())
-	output, err = doRunner.Run(wr.RunnerCtx.GetInput())
+	output, err = doRunner.Run(wr.RunnerCtx.GetInput(), wr)
 	if err != nil {
 		return nil, err
 	}

--- a/impl/task_runner.go
+++ b/impl/task_runner.go
@@ -28,7 +28,7 @@ var _ TaskRunner = &ForTaskRunner{}
 var _ TaskRunner = &DoTaskRunner{}
 
 type TaskRunner interface {
-	Run(input interface{}) (interface{}, error)
+	Run(input interface{}, taskSupport TaskSupport) (interface{}, error)
 	GetTaskName() string
 }
 

--- a/impl/task_runner_call_http.go
+++ b/impl/task_runner_call_http.go
@@ -1,0 +1,44 @@
+// Copyright 2025 The Serverless Workflow Specification Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package impl
+
+import (
+	"fmt"
+
+	"github.com/serverlessworkflow/sdk-go/v3/model"
+)
+
+type CallHTTPTaskRunner struct {
+	TaskName string
+}
+
+func NewCallHttpRunner(taskName string, task *model.CallHTTP) (taskRunner *CallHTTPTaskRunner, err error) {
+	if task == nil {
+		err = model.NewErrValidation(fmt.Errorf("invalid For task %s", taskName), taskName)
+	} else {
+		taskRunner = new(CallHTTPTaskRunner)
+		taskRunner.TaskName = taskName
+	}
+	return
+}
+
+func (f *CallHTTPTaskRunner) Run(input interface{}, taskSupport TaskSupport) (interface{}, error) {
+	return input, nil
+
+}
+
+func (f *CallHTTPTaskRunner) GetTaskName() string {
+	return f.TaskName
+}

--- a/impl/task_runner_do.go
+++ b/impl/task_runner_do.go
@@ -30,9 +30,9 @@ func NewTaskRunner(taskName string, task model.Task, workflowDef *model.Workflow
 	case *model.RaiseTask:
 		return NewRaiseTaskRunner(taskName, t, workflowDef)
 	case *model.DoTask:
-		return NewDoTaskRunner(t.Do, workflowDef)
+		return NewDoTaskRunner(t.Do)
 	case *model.ForTask:
-		return NewForTaskRunner(taskName, t, workflowDef)
+		return NewForTaskRunner(taskName, t)
 	case *model.CallHTTP:
 		return NewCallHttpRunner(taskName, t)
 	default:
@@ -40,16 +40,14 @@ func NewTaskRunner(taskName string, task model.Task, workflowDef *model.Workflow
 	}
 }
 
-func NewDoTaskRunner(taskList *model.TaskList, workflowDef *model.Workflow) (*DoTaskRunner, error) {
+func NewDoTaskRunner(taskList *model.TaskList) (*DoTaskRunner, error) {
 	return &DoTaskRunner{
-		TaskList:    taskList,
-		WorkflowDef: workflowDef,
+		TaskList: taskList,
 	}, nil
 }
 
 type DoTaskRunner struct {
-	TaskList    *model.TaskList
-	WorkflowDef *model.Workflow
+	TaskList *model.TaskList
 }
 
 func (d *DoTaskRunner) Run(input interface{}, taskSupport TaskSupport) (output interface{}, err error) {

--- a/impl/task_runner_for.go
+++ b/impl/task_runner_for.go
@@ -28,12 +28,12 @@ const (
 	forTaskDefaultAt   = "$index"
 )
 
-func NewForTaskRunner(taskName string, task *model.ForTask, workflowDef *model.Workflow) (*ForTaskRunner, error) {
+func NewForTaskRunner(taskName string, task *model.ForTask) (*ForTaskRunner, error) {
 	if task == nil || task.Do == nil {
 		return nil, model.NewErrValidation(fmt.Errorf("invalid For task %s", taskName), taskName)
 	}
 
-	doRunner, err := NewDoTaskRunner(task.Do, workflowDef)
+	doRunner, err := NewDoTaskRunner(task.Do)
 	if err != nil {
 		return nil, err
 	}

--- a/impl/task_runner_raise_test.go
+++ b/impl/task_runner_raise_test.go
@@ -45,10 +45,11 @@ func TestRaiseTaskRunner_WithDefinedError(t *testing.T) {
 	assert.NoError(t, err)
 	wfCtx.SetTaskReference("task_raise_defined")
 
-	runner, err := NewRaiseTaskRunner("task_raise_defined", raiseTask, newTaskSupport(withRunnerCtx(wfCtx)))
+	taskSupport := newTaskSupport(withRunnerCtx(wfCtx))
+	runner, err := NewRaiseTaskRunner("task_raise_defined", raiseTask, taskSupport.GetWorkflowDef())
 	assert.NoError(t, err)
 
-	output, err := runner.Run(input)
+	output, err := runner.Run(input, taskSupport)
 	assert.Equal(t, output, input)
 	assert.Error(t, err)
 
@@ -76,7 +77,7 @@ func TestRaiseTaskRunner_WithReferencedError(t *testing.T) {
 		},
 	}
 
-	runner, err := NewRaiseTaskRunner("task_raise_ref", raiseTask, newTaskSupport())
+	runner, err := NewRaiseTaskRunner("task_raise_ref", raiseTask, &model.Workflow{})
 	assert.Error(t, err)
 	assert.Nil(t, runner)
 }
@@ -103,10 +104,11 @@ func TestRaiseTaskRunner_TimeoutErrorWithExpression(t *testing.T) {
 	assert.NoError(t, err)
 	wfCtx.SetTaskReference("task_raise_timeout_expr")
 
-	runner, err := NewRaiseTaskRunner("task_raise_timeout_expr", raiseTask, newTaskSupport(withRunnerCtx(wfCtx)))
+	taskSupport := newTaskSupport(withRunnerCtx(wfCtx))
+	runner, err := NewRaiseTaskRunner("task_raise_timeout_expr", raiseTask, taskSupport.GetWorkflowDef())
 	assert.NoError(t, err)
 
-	output, err := runner.Run(input)
+	output, err := runner.Run(input, taskSupport)
 	assert.Equal(t, input, output)
 	assert.Error(t, err)
 

--- a/impl/task_runner_set.go
+++ b/impl/task_runner_set.go
@@ -20,30 +20,28 @@ import (
 	"github.com/serverlessworkflow/sdk-go/v3/model"
 )
 
-func NewSetTaskRunner(taskName string, task *model.SetTask, taskSupport TaskSupport) (*SetTaskRunner, error) {
+func NewSetTaskRunner(taskName string, task *model.SetTask) (*SetTaskRunner, error) {
 	if task == nil || task.Set == nil {
 		return nil, model.NewErrValidation(fmt.Errorf("no set configuration provided for SetTask %s", taskName), taskName)
 	}
 	return &SetTaskRunner{
-		Task:        task,
-		TaskName:    taskName,
-		TaskSupport: taskSupport,
+		Task:     task,
+		TaskName: taskName,
 	}, nil
 }
 
 type SetTaskRunner struct {
-	Task        *model.SetTask
-	TaskName    string
-	TaskSupport TaskSupport
+	Task     *model.SetTask
+	TaskName string
 }
 
 func (s *SetTaskRunner) GetTaskName() string {
 	return s.TaskName
 }
 
-func (s *SetTaskRunner) Run(input interface{}) (output interface{}, err error) {
+func (s *SetTaskRunner) Run(input interface{}, taskSupport TaskSupport) (output interface{}, err error) {
 	setObject := deepClone(s.Task.Set)
-	result, err := traverseAndEvaluate(model.NewObjectOrRuntimeExpr(setObject), input, s.TaskName, s.TaskSupport.GetContext())
+	result, err := traverseAndEvaluate(model.NewObjectOrRuntimeExpr(setObject), input, s.TaskName, taskSupport.GetContext())
 	if err != nil {
 		return nil, err
 	}

--- a/impl/task_set_test.go
+++ b/impl/task_set_test.go
@@ -45,10 +45,10 @@ func TestSetTaskExecutor_Exec(t *testing.T) {
 		},
 	}
 
-	executor, err := NewSetTaskRunner("task1", setTask, newTaskSupport())
+	executor, err := NewSetTaskRunner("task1", setTask)
 	assert.NoError(t, err)
 
-	output, err := executor.Run(input)
+	output, err := executor.Run(input, newTaskSupport())
 	assert.NoError(t, err)
 
 	expectedOutput := map[string]interface{}{
@@ -79,10 +79,10 @@ func TestSetTaskExecutor_StaticValues(t *testing.T) {
 		},
 	}
 
-	executor, err := NewSetTaskRunner("task_static", setTask, newTaskSupport())
+	executor, err := NewSetTaskRunner("task_static", setTask)
 	assert.NoError(t, err)
 
-	output, err := executor.Run(input)
+	output, err := executor.Run(input, newTaskSupport())
 	assert.NoError(t, err)
 
 	expectedOutput := map[string]interface{}{
@@ -109,10 +109,10 @@ func TestSetTaskExecutor_RuntimeExpressions(t *testing.T) {
 		},
 	}
 
-	executor, err := NewSetTaskRunner("task_runtime_expr", setTask, newTaskSupport())
+	executor, err := NewSetTaskRunner("task_runtime_expr", setTask)
 	assert.NoError(t, err)
 
-	output, err := executor.Run(input)
+	output, err := executor.Run(input, newTaskSupport())
 	assert.NoError(t, err)
 
 	expectedOutput := map[string]interface{}{
@@ -141,10 +141,10 @@ func TestSetTaskExecutor_NestedStructures(t *testing.T) {
 		},
 	}
 
-	executor, err := NewSetTaskRunner("task_nested_structures", setTask, newTaskSupport())
+	executor, err := NewSetTaskRunner("task_nested_structures", setTask)
 	assert.NoError(t, err)
 
-	output, err := executor.Run(input)
+	output, err := executor.Run(input, newTaskSupport())
 	assert.NoError(t, err)
 
 	expectedOutput := map[string]interface{}{
@@ -176,10 +176,10 @@ func TestSetTaskExecutor_StaticAndDynamicValues(t *testing.T) {
 		},
 	}
 
-	executor, err := NewSetTaskRunner("task_static_dynamic", setTask, newTaskSupport())
+	executor, err := NewSetTaskRunner("task_static_dynamic", setTask)
 	assert.NoError(t, err)
 
-	output, err := executor.Run(input)
+	output, err := executor.Run(input, newTaskSupport())
 	assert.NoError(t, err)
 
 	expectedOutput := map[string]interface{}{
@@ -201,10 +201,10 @@ func TestSetTaskExecutor_MissingInputData(t *testing.T) {
 		},
 	}
 
-	executor, err := NewSetTaskRunner("task_missing_input", setTask, newTaskSupport())
+	executor, err := NewSetTaskRunner("task_missing_input", setTask)
 	assert.NoError(t, err)
 
-	output, err := executor.Run(input)
+	output, err := executor.Run(input, newTaskSupport())
 	assert.NoError(t, err)
 	assert.Nil(t, output.(map[string]interface{})["value"])
 }
@@ -220,10 +220,10 @@ func TestSetTaskExecutor_ExpressionsWithFunctions(t *testing.T) {
 		},
 	}
 
-	executor, err := NewSetTaskRunner("task_expr_functions", setTask, newTaskSupport())
+	executor, err := NewSetTaskRunner("task_expr_functions", setTask)
 	assert.NoError(t, err)
 
-	output, err := executor.Run(input)
+	output, err := executor.Run(input, newTaskSupport())
 	assert.NoError(t, err)
 
 	expectedOutput := map[string]interface{}{
@@ -246,10 +246,10 @@ func TestSetTaskExecutor_ConditionalExpressions(t *testing.T) {
 		},
 	}
 
-	executor, err := NewSetTaskRunner("task_conditional_expr", setTask, newTaskSupport())
+	executor, err := NewSetTaskRunner("task_conditional_expr", setTask)
 	assert.NoError(t, err)
 
-	output, err := executor.Run(input)
+	output, err := executor.Run(input, newTaskSupport())
 	assert.NoError(t, err)
 
 	expectedOutput := map[string]interface{}{
@@ -273,10 +273,10 @@ func TestSetTaskExecutor_ArrayDynamicIndex(t *testing.T) {
 		},
 	}
 
-	executor, err := NewSetTaskRunner("task_array_indexing", setTask, newTaskSupport())
+	executor, err := NewSetTaskRunner("task_array_indexing", setTask)
 	assert.NoError(t, err)
 
-	output, err := executor.Run(input)
+	output, err := executor.Run(input, newTaskSupport())
 	assert.NoError(t, err)
 
 	expectedOutput := map[string]interface{}{
@@ -299,10 +299,10 @@ func TestSetTaskExecutor_NestedConditionalLogic(t *testing.T) {
 		},
 	}
 
-	executor, err := NewSetTaskRunner("task_nested_condition", setTask, newTaskSupport())
+	executor, err := NewSetTaskRunner("task_nested_condition", setTask)
 	assert.NoError(t, err)
 
-	output, err := executor.Run(input)
+	output, err := executor.Run(input, newTaskSupport())
 	assert.NoError(t, err)
 
 	expectedOutput := map[string]interface{}{
@@ -323,10 +323,10 @@ func TestSetTaskExecutor_DefaultValues(t *testing.T) {
 		},
 	}
 
-	executor, err := NewSetTaskRunner("task_default_values", setTask, newTaskSupport())
+	executor, err := NewSetTaskRunner("task_default_values", setTask)
 	assert.NoError(t, err)
 
-	output, err := executor.Run(input)
+	output, err := executor.Run(input, newTaskSupport())
 	assert.NoError(t, err)
 
 	expectedOutput := map[string]interface{}{
@@ -363,10 +363,10 @@ func TestSetTaskExecutor_ComplexNestedStructures(t *testing.T) {
 		},
 	}
 
-	executor, err := NewSetTaskRunner("task_complex_nested", setTask, newTaskSupport())
+	executor, err := NewSetTaskRunner("task_complex_nested", setTask)
 	assert.NoError(t, err)
 
-	output, err := executor.Run(input)
+	output, err := executor.Run(input, newTaskSupport())
 	assert.NoError(t, err)
 
 	expectedOutput := map[string]interface{}{
@@ -399,10 +399,10 @@ func TestSetTaskExecutor_MultipleExpressions(t *testing.T) {
 		},
 	}
 
-	executor, err := NewSetTaskRunner("task_multiple_expr", setTask, newTaskSupport())
+	executor, err := NewSetTaskRunner("task_multiple_expr", setTask)
 	assert.NoError(t, err)
 
-	output, err := executor.Run(input)
+	output, err := executor.Run(input, newTaskSupport())
 	assert.NoError(t, err)
 
 	expectedOutput := map[string]interface{}{


### PR DESCRIPTION
This potentially allows creating TaskRunner object without TaskSupport (so TaskRunners can be reused to execute different workflow instances) 