### PR TITLE
Added proxy auth support to model.Endpoint

### DIFF
--- a/model/authentication.go
+++ b/model/authentication.go
@@ -185,9 +185,11 @@ type BearerAuthenticationPolicy struct {
 	Use   string `json:"use,omitempty" validate:"required_without=Token"`
 }
 
+// ProxyBearerAuthenticationPolicy supports either an inline token or a secret reference (use).
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Proxy-Authorization
 type ProxyBearerAuthenticationPolicy struct {
 	Token string `json:"token,omitempty" validate:"required_without=Use,proxy_bearer_policy"`
-	Use   string `json:"use,omitempty" validate:"required"`
+	Use   string `json:"use,omitempty" validate:"required_without=Token"`
 }
 
 // DigestAuthenticationPolicy supports either inline properties (username/password) or a secret reference (use).

--- a/model/authentication_test.go
+++ b/model/authentication_test.go
@@ -49,6 +49,16 @@ func TestAuthenticationPolicy(t *testing.T) {
 			expected:   `{"digest":{"username":"digestUser","password":"digestPass"}}`,
 			expectsErr: false,
 		},
+		{
+			name: "Valid Proxy Bearer Authentication Inline",
+			input: `{
+				"proxy_bearer": {
+					"token": "proxyToken123"
+				}
+			}`,
+			expected:   `{"proxy_bearer":{"token":"proxyToken123"}}`,
+			expectsErr: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -63,6 +73,9 @@ func TestAuthenticationPolicy(t *testing.T) {
 				}
 				if authPolicy.Bearer != nil {
 					err = validate.Struct(authPolicy.Bearer)
+				}
+				if authPolicy.ProxyBearer != nil {
+					err = validate.Struct(authPolicy.ProxyBearer)
 				}
 				if authPolicy.Digest != nil {
 					err = validate.Struct(authPolicy.Digest)

--- a/model/validator.go
+++ b/model/validator.go
@@ -43,6 +43,7 @@ func init() {
 
 	registerValidator("basic_policy", validateBasicPolicy)
 	registerValidator("bearer_policy", validateBearerPolicy)
+	registerValidator("proxy_bearer_policy", validateProxyBearerPolicy)
 	registerValidator("digest_policy", validateDigestPolicy)
 	registerValidator("oauth2_policy", validateOAuth2Policy)
 	registerValidator("client_auth_type", validateOptionalOAuthClientAuthentication)
@@ -177,6 +178,18 @@ func validateBasicPolicy(fl validator.FieldLevel) bool {
 // validateBearerPolicy ensures BearerAuthenticationPolicy has mutually exclusive fields set.
 func validateBearerPolicy(fl validator.FieldLevel) bool {
 	policy, ok := fl.Parent().Interface().(BearerAuthenticationPolicy)
+	if !ok {
+		return false
+	}
+	if policy.Token != "" && policy.Use != "" {
+		return false
+	}
+	return true
+}
+
+// validateProxyBearerPolicy ensures ProxyBearerAuthenticationPolicy has mutually exclusive fields set.
+func validateProxyBearerPolicy(fl validator.FieldLevel) bool {
+	policy, ok := fl.Parent().Interface().(ProxyBearerAuthenticationPolicy)
 	if !ok {
 		return false
 	}


### PR DESCRIPTION
Adding support for https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Proxy-Authorization. Is this ok? Do you want me to update the DSL spec first?

Just lets HTTP callers auth against resources that support the proxy auth header like Google's IAP