### PR TITLE
Fix test failure with gojq 0.12.19 - use int instead of int32

### DIFF
--- a/impl/runner_test.go
+++ b/impl/runner_test.go
@@ -402,7 +402,7 @@ func TestForTaskRunner_Run(t *testing.T) {
 	t.Run("SUM Numbers", func(t *testing.T) {
 		workflowPath := "./testdata/for_sum_numbers.yaml"
 		input := map[string]interface{}{
-			"numbers": []int32{2, 3, 4},
+			"numbers": []int{2, 3, 4},
 		}
 		expectedOutput := map[string]interface{}{
 			"result": interface{}(9),


### PR DESCRIPTION
## Summary
- Fixes test failure in PR #264 caused by gojq v0.12.18+ breaking change
- Changes `[]int32` to `[]int` in the SUM_Numbers test

## Root Cause
gojq v0.12.18 introduced a breaking change that stopped numeric normalization for concurrent execution. This means `int32` values are no longer automatically normalized to `int`, causing evaluation errors.

gojq only supports these types:
- `nil`, `bool`, `int`, `float64`, `*big.Int`, `string`, `[]any`, `map[string]any`

When the test passes `[]int32{2, 3, 4}`, gojq v0.12.19 throws:
```
jq evaluation error: %!v(PANIC=Error method: invalid type: int32 (2))
```

## Changes
Changed line 405 in `impl/runner_test.go`:
```diff
- "numbers": []int32{2, 3, 4},
+ "numbers": []int{2, 3, 4},
```

## Test Plan
All tests pass after this change:
```
✓ github.com/serverlessworkflow/sdk-go/v3/impl	2.635s	coverage: 80.1% of statements
```

## References
- Fixes test failure in #264
- [gojq v0.12.18 changelog](https://github.com/itchyny/gojq/blob/main/CHANGELOG.md): "stop numeric normalization for concurrent execution"

🤖 Generated with [Claude Code](https://claude.com/claude-code)