### PR TITLE
Rename to Open Workflow Spec - Prepare for v4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug encountered with the Serverless Workflow Go SDK
+about: Report a bug encountered with the Open Workflow Go SDK
 labels: "bug :bug:"
 
 ---

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,6 +1,6 @@
 ---
 name: Enhancement Request
-about: Suggest an enhancement to the Serverless Workflow Go SDK
+about: Suggest an enhancement to the Open Workflow Go SDK
 labels: "enhancement :pray:"
 
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Ask a question about the Serverless Workflow Go SDK
+about: Ask a question about the Open Workflow Go SDK
 labels: "question :question:"
 
 ---

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Copyright 2026 The Serverless Workflow Specification Authors
+# Copyright 2026 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/Go-SDK-PR-Check.yaml
+++ b/.github/workflows/Go-SDK-PR-Check.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 The Serverless Workflow Specification Authors
+# Copyright 2022 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,4 @@
-# Serverless Workflow Go SDK Maintainers
+# Open Workflow Go SDK Maintainers
 
 * [Ricardo Zanini](https://github.com/ricardozanini)
 * [Filippe Spolti](https://github.com/spolti)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 addheaders:
 	@command -v addlicense > /dev/null || (echo "🚀 Installing addlicense..."; go install -modfile=tools.mod -v github.com/google/addlicense)
-	@addlicense -c "The Serverless Workflow Specification Authors" -l apache .
+	@addlicense -c "The Open Workflow Specification Authors" -l apache .
 
 fmt:
 	@go vet ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Go SDK for Serverless Workflow
+# Go SDK for Open Workflow
 
-The Go SDK for Serverless Workflow provides strongly-typed structures for the [Serverless Workflow specification](https://github.com/serverlessworkflow/specification/blob/v1.0.0/schema/workflow.yaml). It simplifies parsing, validating, and interacting with workflows in Go. Starting from version `v3.1.0`, the SDK also includes a partial reference implementation, allowing users to execute workflows directly within their Go applications.
+The Go SDK for Open Workflow provides strongly-typed structures for the [Open Workflow specification](https://github.com/open-workflow-specification/specification/blob/v1.0.0/schema/workflow.yaml). It simplifies parsing, validating, and interacting with workflows in Go. Starting from version `v4.0.0`, the SDK also includes a partial reference implementation, allowing users to execute workflows directly within their Go applications.
 
 ---
 
@@ -44,11 +44,11 @@ This table indicates the current state of implementation of various SDK features
 
 |                              Latest Releases                               |                            Conformance to Spec Version                            |
 |:--------------------------------------------------------------------------:|:---------------------------------------------------------------------------------:|
-| [v1.0.0](https://github.com/serverlessworkflow/sdk-go/releases/tag/v1.0.0) |      [v0.5](https://github.com/serverlessworkflow/specification/tree/0.5.x)       |
-| [v2.0.1](https://github.com/serverlessworkflow/sdk-go/releases/tag/v2.0.1) |      [v0.6](https://github.com/serverlessworkflow/specification/tree/0.6.x)       |
-| [v2.1.2](https://github.com/serverlessworkflow/sdk-go/releases/tag/v2.1.2) |      [v0.7](https://github.com/serverlessworkflow/specification/tree/0.7.x)       |
-| [v2.5.0](https://github.com/serverlessworkflow/sdk-go/releases/tag/v2.5.0) |      [v0.8](https://github.com/serverlessworkflow/specification/tree/0.8.x)       |
-| [v3.4.0](https://github.com/serverlessworkflow/sdk-go/releases/tag/v3.4.0) | [v1.0.0](https://github.com/serverlessworkflow/specification/releases/tag/v1.0.0) |
+| [v1.0.0](https://github.com/open-workflow-specification/sdk-go/releases/tag/v1.0.0) |      [v0.5](https://github.com/open-workflow-specification/specification/tree/0.5.x)       |
+| [v2.0.1](https://github.com/open-workflow-specification/sdk-go/releases/tag/v2.0.1) |      [v0.6](https://github.com/open-workflow-specification/specification/tree/0.6.x)       |
+| [v2.1.2](https://github.com/open-workflow-specification/sdk-go/releases/tag/v2.1.2) |      [v0.7](https://github.com/open-workflow-specification/specification/tree/0.7.x)       |
+| [v2.5.0](https://github.com/open-workflow-specification/sdk-go/releases/tag/v2.5.0) |      [v0.8](https://github.com/open-workflow-specification/specification/tree/0.8.x)       |
+| [v3.4.0](https://github.com/open-workflow-specification/sdk-go/releases/tag/v3.4.0) | [v1.0.0](https://github.com/open-workflow-specification/specification/releases/tag/v1.0.0) |
 
 ---
 
@@ -68,7 +68,7 @@ document:
   version: "1.0.0"
 do:
   - set:
-      message: "Hello from the Serverless Workflow SDK in Go!"
+      message: "Hello from the Open Workflow SDK in Go!"
 ```
 
 You can execute this workflow using the following Go program:
@@ -83,8 +83,8 @@ import (
     "os"
     "path/filepath"
 
-    "github.com/serverlessworkflow/sdk-go/v3/impl"
-    "github.com/serverlessworkflow/sdk-go/v3/parser"
+    "github.com/open-workflow-specification/sdk-go/v4/impl"
+    "github.com/open-workflow-specification/sdk-go/v4/parser"
 )
 
 func RunWorkflow(workflowFilePath string, input map[string]interface{}) (interface{}, error) {
@@ -116,7 +116,7 @@ func main() {
 
 ### Implementation Roadmap
 
-The table below lists the current state of this implementation. This table is a roadmap for the project based on the [DSL Reference doc](https://github.com/serverlessworkflow/specification/blob/v1.0.0/dsl-reference.md).
+The table below lists the current state of this implementation. This table is a roadmap for the project based on the [DSL Reference doc](https://github.com/open-workflow-specification/specification/blob/v1.0.0/dsl-reference.md).
 
 | Feature | State |
 | ----------- | --------------- |
@@ -160,9 +160,9 @@ The table below lists the current state of this implementation. This table is a 
 | Workflow Definition Reference | ✅ |
 | Subscription Iterator | ❌ |
 
-We love contributions! Our aim is to have a complete implementation to serve as a reference or to become a project on its own to favor the CNCF Ecosystem.
+We love contributions! Our aim is to have a complete implementation to serve as a reference or to become a project on its own to favor the Open Workflow ecosystem.
 
-If you are willing to help, please [file a sub-task](https://github.com/serverlessworkflow/sdk-go/issues/221) in this EPIC describing what you are planning to work on first.
+If you are willing to help, please [file a sub-task](https://github.com/open-workflow-specification/sdk-go/issues/221) in this EPIC describing what you are planning to work on first.
 
 ---
 
@@ -209,6 +209,6 @@ brew install diffutils
 
 ---
 
-Contributions are greatly appreciated! Check [this EPIC](https://github.com/serverlessworkflow/sdk-go/issues/221) and contribute to completing more features.
+Contributions are greatly appreciated! Check [this EPIC](https://github.com/open-workflow-specification/sdk-go/issues/221) and contribute to completing more features.
 
 Happy coding!

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Serverless Workflow Specification Authors
+// Copyright 2023 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 
 	"sigs.k8s.io/yaml"
 )

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Serverless Workflow Specification Authors
+// Copyright 2023 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import (
 	"testing"
 
 	validator "github.com/go-playground/validator/v10"
-	"github.com/serverlessworkflow/sdk-go/v3/model"
-	"github.com/serverlessworkflow/sdk-go/v3/test"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
+	"github.com/open-workflow-specification/sdk-go/v4/test"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Serverless Workflow Specification Authors
+# Copyright 2020 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/serverlessworkflow/sdk-go/v3
+module github.com/open-workflow-specification/sdk-go/v4
 
 go 1.25.0
 

--- a/hack/boilerplate.txt
+++ b/hack/boilerplate.txt
@@ -1,4 +1,4 @@
-// Copyright 2023 The Serverless Workflow Specification Authors
+// Copyright 2023 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2020 The Serverless Workflow Specification Authors
+# Copyright 2020 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 # Script to fetch workflow examples, parse, and validate them using the Go parser.
 
 # Variables
-SPEC_REPO="https://github.com/serverlessworkflow/specification"
+SPEC_REPO="https://github.com/open-workflow-specification/specification"
 EXAMPLES_DIR="examples"
 PARSER_BINARY="./parser/cmd/main.go"
 JUNIT_FILE="./integration-test-junit.xml"

--- a/impl/ctx/context.go
+++ b/impl/ctx/context.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/serverlessworkflow/sdk-go/v3/impl/utils"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/utils"
 
 	"github.com/google/uuid"
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 )
 
 var ErrWorkflowContextNotFound = errors.New("workflow context not found")
@@ -45,8 +45,8 @@ const (
 	varsTask     = "$task"
 
 	// TODO: script during the release to update this value programmatically
-	runtimeVersion = "v3.1.0"
-	runtimeName    = "CNCF Serverless Workflow Specification Go SDK"
+	runtimeVersion = "v4.0.0"
+	runtimeName    = "Open Workflow Specification Go SDK"
 )
 
 type WorkflowContext interface {

--- a/impl/ctx/status_phase.go
+++ b/impl/ctx/status_phase.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/impl/expr/expr.go
+++ b/impl/expr/expr.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import (
 	"fmt"
 
 	"github.com/itchyny/gojq"
-	"github.com/serverlessworkflow/sdk-go/v3/impl/ctx"
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/ctx"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 )
 
 func TraverseAndEvaluateWithVars(node interface{}, input interface{}, variables map[string]interface{}, nodeContext context.Context) (interface{}, error) {

--- a/impl/expr/expr_test.go
+++ b/impl/expr/expr_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/impl/json_pointer.go
+++ b/impl/json_pointer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 )
 
 func findJsonPointer(data interface{}, target string, path string) (string, bool) {

--- a/impl/json_pointer_test.go
+++ b/impl/json_pointer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package impl
 import (
 	"testing"
 
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/impl/runner.go
+++ b/impl/runner.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/serverlessworkflow/sdk-go/v3/impl/expr"
-	"github.com/serverlessworkflow/sdk-go/v3/impl/utils"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/expr"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/utils"
 
-	"github.com/serverlessworkflow/sdk-go/v3/impl/ctx"
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/ctx"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 )
 
 var _ WorkflowRunner = &workflowRunnerImpl{}

--- a/impl/runner_test.go
+++ b/impl/runner_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/serverlessworkflow/sdk-go/v3/impl/ctx"
-	"github.com/serverlessworkflow/sdk-go/v3/model"
-	"github.com/serverlessworkflow/sdk-go/v3/parser"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/ctx"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
+	"github.com/open-workflow-specification/sdk-go/v4/parser"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/impl/task_runner.go
+++ b/impl/task_runner.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/serverlessworkflow/sdk-go/v3/impl/ctx"
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/ctx"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 )
 
 var _ TaskRunner = &SetTaskRunner{}

--- a/impl/task_runner_call_http.go
+++ b/impl/task_runner_call_http.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package impl
 import (
 	"fmt"
 
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 )
 
 type CallHTTPTaskRunner struct {

--- a/impl/task_runner_do.go
+++ b/impl/task_runner_do.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/serverlessworkflow/sdk-go/v3/impl/expr"
-	"github.com/serverlessworkflow/sdk-go/v3/impl/utils"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/expr"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/utils"
 
-	"github.com/serverlessworkflow/sdk-go/v3/impl/ctx"
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/ctx"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 )
 
 // NewTaskRunner creates a TaskRunner instance based on the task type.

--- a/impl/task_runner_for.go
+++ b/impl/task_runner_for.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/serverlessworkflow/sdk-go/v3/impl/expr"
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/expr"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 )
 
 const (

--- a/impl/task_runner_fork.go
+++ b/impl/task_runner_fork.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 )
 
 func NewForkTaskRunner(taskName string, task *model.ForkTask, workflowDef *model.Workflow) (*ForkTaskRunner, error) {

--- a/impl/task_runner_fork_test.go
+++ b/impl/task_runner_fork_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/impl/task_runner_raise.go
+++ b/impl/task_runner_raise.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package impl
 import (
 	"fmt"
 
-	"github.com/serverlessworkflow/sdk-go/v3/impl/expr"
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/expr"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 )
 
 func NewRaiseTaskRunner(taskName string, task *model.RaiseTask, workflowDef *model.Workflow) (*RaiseTaskRunner, error) {

--- a/impl/task_runner_raise_test.go
+++ b/impl/task_runner_raise_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/serverlessworkflow/sdk-go/v3/impl/ctx"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/ctx"
 
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/impl/task_runner_set.go
+++ b/impl/task_runner_set.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package impl
 import (
 	"fmt"
 
-	"github.com/serverlessworkflow/sdk-go/v3/impl/expr"
-	"github.com/serverlessworkflow/sdk-go/v3/impl/utils"
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/expr"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/utils"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 )
 
 func NewSetTaskRunner(taskName string, task *model.SetTask) (*SetTaskRunner, error) {

--- a/impl/task_runner_set_test.go
+++ b/impl/task_runner_set_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/impl/task_runner_wait.go
+++ b/impl/task_runner_wait.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/serverlessworkflow/sdk-go/v3/impl/ctx"
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/impl/ctx"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 )
 
 func NewWaitTaskRunner(taskName string, task *model.WaitTask) (*WaitTaskRunner, error) {

--- a/impl/task_runner_wait_test.go
+++ b/impl/task_runner_wait_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/impl/testdata/chained_set_tasks.yaml
+++ b/impl/testdata/chained_set_tasks.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/concatenating_strings.yaml
+++ b/impl/testdata/concatenating_strings.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/conditional_logic.yaml
+++ b/impl/testdata/conditional_logic.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/conditional_logic_input_from.yaml
+++ b/impl/testdata/conditional_logic_input_from.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/for_colors.yaml
+++ b/impl/testdata/for_colors.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/for_nested_loops.yaml
+++ b/impl/testdata/for_nested_loops.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/for_sum_numbers.yaml
+++ b/impl/testdata/for_sum_numbers.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/fork_simple.yaml
+++ b/impl/testdata/fork_simple.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/raise_conditional.yaml
+++ b/impl/testdata/raise_conditional.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# $schema: https://raw.githubusercontent.com/serverlessworkflow/specification/refs/heads/main/schema/workflow.yaml
+# $schema: https://raw.githubusercontent.com/open-workflow-specification/specification/refs/heads/main/schema/workflow.yaml
 document:
   dsl: '1.0.0-alpha5'
   namespace: test
@@ -23,7 +23,7 @@ do:
       if: ${ .user.age < 18 }
       raise:
         error:
-          type: https://serverlessworkflow.io/spec/1.0.0/errors/authorization
+          type: https://open-workflow-specification.org/spec/1.0.0/errors/authorization
           status: 403
           title: Authorization Error
           detail: "User is under the required age"

--- a/impl/testdata/raise_error_with_input.yaml
+++ b/impl/testdata/raise_error_with_input.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ do:
   - dynamicError:
       raise:
         error:
-          type: https://serverlessworkflow.io/spec/1.0.0/errors/authentication
+          type: https://open-workflow-specification.org/spec/1.0.0/errors/authentication
           status: 401
           title: Authentication Error
           detail: '${ "User authentication failed: \( .reason )" }'

--- a/impl/testdata/raise_inline.yaml
+++ b/impl/testdata/raise_inline.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ do:
   - inlineError:
       raise:
         error:
-          type: https://serverlessworkflow.io/spec/1.0.0/errors/validation
+          type: https://open-workflow-specification.org/spec/1.0.0/errors/validation
           status: 400
           title: Validation Error
           detail: ${ "Invalid input provided to workflow \($workflow.definition.document.name)" }

--- a/impl/testdata/raise_reusable.yaml
+++ b/impl/testdata/raise_reusable.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ document:
 use:
   errors:
     AuthenticationError:
-      type: https://serverlessworkflow.io/spec/1.0.0/errors/authentication
+      type: https://open-workflow-specification.org/spec/1.0.0/errors/authentication
       status: 401
       title: Authentication Error
       detail: "User is not authenticated"

--- a/impl/testdata/raise_undefined_reference.yaml
+++ b/impl/testdata/raise_undefined_reference.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/sequential_set_colors.yaml
+++ b/impl/testdata/sequential_set_colors.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/sequential_set_colors_output_as.yaml
+++ b/impl/testdata/sequential_set_colors_output_as.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/set_tasks_invalid_then.yaml
+++ b/impl/testdata/set_tasks_invalid_then.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/set_tasks_with_termination.yaml
+++ b/impl/testdata/set_tasks_with_termination.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/set_tasks_with_then.yaml
+++ b/impl/testdata/set_tasks_with_then.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/switch_match.yaml
+++ b/impl/testdata/switch_match.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/switch_with_default.yaml
+++ b/impl/testdata/switch_with_default.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/task_export_schema.yaml
+++ b/impl/testdata/task_export_schema.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/task_input_schema.yaml
+++ b/impl/testdata/task_input_schema.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/task_output_schema.yaml
+++ b/impl/testdata/task_output_schema.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/task_output_schema_with_dynamic_value.yaml
+++ b/impl/testdata/task_output_schema_with_dynamic_value.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/wait_duration_iso8601.yaml
+++ b/impl/testdata/wait_duration_iso8601.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/testdata/workflow_input_schema.yaml
+++ b/impl/testdata/workflow_input_schema.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/impl/utils/json_schema.go
+++ b/impl/utils/json_schema.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 	"github.com/xeipuuv/gojsonschema"
 )
 

--- a/impl/utils/utils.go
+++ b/impl/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/authentication_oauth.go
+++ b/model/authentication_oauth.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/authentication_oauth_test.go
+++ b/model/authentication_oauth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/authentication_test.go
+++ b/model/authentication_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/builder.go
+++ b/model/builder.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/duration.go
+++ b/model/duration.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/duration_test.go
+++ b/model/duration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/duration_utils.go
+++ b/model/duration_utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/endpoint.go
+++ b/model/endpoint.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/endpoint_test.go
+++ b/model/endpoint_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/errors.go
+++ b/model/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,17 +21,17 @@ import (
 	"strings"
 )
 
-// List of Standard Errors based on the Serverless Workflow specification.
-// See: https://github.com/serverlessworkflow/specification/blob/main/dsl-reference.md#standard-error-types
+// List of Standard Errors based on the Open Workflow specification.
+// See: https://github.com/open-workflow-specification/specification/blob/main/dsl-reference.md#standard-error-types
 const (
-	ErrorTypeConfiguration  = "https://serverlessworkflow.io/spec/1.0.0/errors/configuration"
-	ErrorTypeValidation     = "https://serverlessworkflow.io/spec/1.0.0/errors/validation"
-	ErrorTypeExpression     = "https://serverlessworkflow.io/spec/1.0.0/errors/expression"
-	ErrorTypeAuthentication = "https://serverlessworkflow.io/spec/1.0.0/errors/authentication"
-	ErrorTypeAuthorization  = "https://serverlessworkflow.io/spec/1.0.0/errors/authorization"
-	ErrorTypeTimeout        = "https://serverlessworkflow.io/spec/1.0.0/errors/timeout"
-	ErrorTypeCommunication  = "https://serverlessworkflow.io/spec/1.0.0/errors/communication"
-	ErrorTypeRuntime        = "https://serverlessworkflow.io/spec/1.0.0/errors/runtime"
+	ErrorTypeConfiguration  = "https://open-workflow-specification.org/spec/1.0.0/errors/configuration"
+	ErrorTypeValidation     = "https://open-workflow-specification.org/spec/1.0.0/errors/validation"
+	ErrorTypeExpression     = "https://open-workflow-specification.org/spec/1.0.0/errors/expression"
+	ErrorTypeAuthentication = "https://open-workflow-specification.org/spec/1.0.0/errors/authentication"
+	ErrorTypeAuthorization  = "https://open-workflow-specification.org/spec/1.0.0/errors/authorization"
+	ErrorTypeTimeout        = "https://open-workflow-specification.org/spec/1.0.0/errors/timeout"
+	ErrorTypeCommunication  = "https://open-workflow-specification.org/spec/1.0.0/errors/communication"
+	ErrorTypeRuntime        = "https://open-workflow-specification.org/spec/1.0.0/errors/runtime"
 )
 
 type Error struct {

--- a/model/extension.go
+++ b/model/extension.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/extension_test.go
+++ b/model/extension_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/objects.go
+++ b/model/objects.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/objects_test.go
+++ b/model/objects_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/runtime_expression.go
+++ b/model/runtime_expression.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/runtime_expression_test.go
+++ b/model/runtime_expression_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task.go
+++ b/model/task.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_call.go
+++ b/model/task_call.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_call_test.go
+++ b/model/task_call_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_do.go
+++ b/model/task_do.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_do_test.go
+++ b/model/task_do_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_event.go
+++ b/model/task_event.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_event_test.go
+++ b/model/task_event_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_for.go
+++ b/model/task_for.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_for_test.go
+++ b/model/task_for_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_fork.go
+++ b/model/task_fork.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_fork_test.go
+++ b/model/task_fork_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_raise.go
+++ b/model/task_raise.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_raise_test.go
+++ b/model/task_raise_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_registry_test.go
+++ b/model/task_registry_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_run.go
+++ b/model/task_run.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_run_test.go
+++ b/model/task_run_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_set.go
+++ b/model/task_set.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_set_test.go
+++ b/model/task_set_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_switch.go
+++ b/model/task_switch.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_switch_test.go
+++ b/model/task_switch_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_test.go
+++ b/model/task_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_try.go
+++ b/model/task_try.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_try_test.go
+++ b/model/task_try_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_wait.go
+++ b/model/task_wait.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/task_wait_test.go
+++ b/model/task_wait_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/timeout.go
+++ b/model/timeout.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/timeout_test.go
+++ b/model/timeout_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/validator.go
+++ b/model/validator.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/validator_test.go
+++ b/model/validator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/model/workflow_test.go
+++ b/model/workflow_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/cmd/main.go
+++ b/parser/cmd/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/serverlessworkflow/sdk-go/v3/parser"
+	"github.com/open-workflow-specification/sdk-go/v4/parser"
 )
 
 func main() {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Serverless Workflow Specification Authors
+// Copyright 2020 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/serverlessworkflow/sdk-go/v3/model"
+	"github.com/open-workflow-specification/sdk-go/v4/model"
 
 	"sigs.k8s.io/yaml"
 )
@@ -34,7 +34,7 @@ const (
 
 var supportedExt = []string{extYAML, extYML, extJSON}
 
-// FromYAMLSource parses the given Serverless Workflow YAML source into the Workflow type.
+// FromYAMLSource parses the given Open Workflow YAML source into the Workflow type.
 func FromYAMLSource(source []byte) (workflow *model.Workflow, err error) {
 	var jsonBytes []byte
 	if jsonBytes, err = yaml.YAMLToJSON(source); err != nil {
@@ -43,7 +43,7 @@ func FromYAMLSource(source []byte) (workflow *model.Workflow, err error) {
 	return FromJSONSource(jsonBytes)
 }
 
-// FromJSONSource parses the given Serverless Workflow JSON source into the Workflow type.
+// FromJSONSource parses the given Open Workflow JSON source into the Workflow type.
 func FromJSONSource(source []byte) (workflow *model.Workflow, err error) {
 	workflow = &model.Workflow{}
 	if err := json.Unmarshal(source, workflow); err != nil {
@@ -57,7 +57,7 @@ func FromJSONSource(source []byte) (workflow *model.Workflow, err error) {
 	return workflow, nil
 }
 
-// FromFile parses the given Serverless Workflow file into the Workflow type.
+// FromFile parses the given Open Workflow file into the Workflow type.
 func FromFile(path string) (*model.Workflow, error) {
 	if err := checkFilePath(path); err != nil {
 		return nil, err

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Serverless Workflow Specification Authors
+// Copyright 2020 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/parser/testdata/invalid_workflow.yaml
+++ b/parser/testdata/invalid_workflow.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/parser/testdata/valid_workflow.yaml
+++ b/parser/testdata/valid_workflow.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 The Serverless Workflow Specification Authors
+# Copyright 2025 The Open Workflow Specification Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/utils.go
+++ b/test/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Serverless Workflow Specification Authors
+// Copyright 2025 The Open Workflow Specification Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Rename from "Serverless Workflow" to "Open Workflow" across the entire codebase
- Update Go module path from `github.com/serverlessworkflow/sdk-go/v3` to `github.com/open-workflow-specification/sdk-go/v4`
- Update error type URIs from `serverlessworkflow.io` to `open-workflow-specification.org`
- Update copyright headers, documentation, CI configs, and hack scripts to reflect the new branding

## Notes

- No schema or API changes — this is a naming/branding update only
- Major version bump (v3 → v4) signals the module path change to consumers
- CNCF references (Code of Conduct, Slack) are intentionally kept